### PR TITLE
Mac fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.16.3)
 
 project(gvsoc)
 
+set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
+
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
     set(CMAKE_C_COMPILER_LAUNCHER   ccache)


### PR DESCRIPTION
These changes, alongside the changes to the [core](https://github.com/gvsoc/gvsoc-core/pull/40) submodule, allow compiling gvsoc on macOS.

Not tested on linux.