### PR TITLE
Add basic memory allocation runtime library

### DIFF
--- a/examples/SoftHier/config/arch_malloc_check.py
+++ b/examples/SoftHier/config/arch_malloc_check.py
@@ -1,0 +1,87 @@
+#
+# Copyright (C) 2020 ETH Zurich and University of Bologna
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Author: Chi Zhang <chizhang@ethz.ch>
+
+class FlexClusterArch:
+
+    def __init__(self):
+
+        #Cluster
+        self.num_cluster_x           = 4
+        self.num_cluster_y           = 4
+        self.num_core_per_cluster    = 3
+
+        self.cluster_tcdm_bank_width = 32
+        self.cluster_tcdm_bank_nb    = 128
+
+        self.cluster_tcdm_base       = 0x00000000
+        self.cluster_tcdm_size       = 0x00100000
+        self.cluster_tcdm_remote     = 0x30000000
+
+        self.cluster_heap_base       = 0x00000100
+        self.cluster_heap_end        = 0x00100000
+
+        self.cluster_stack_base      = 0x10000000
+        self.cluster_stack_size      = 0x00020000
+
+        self.cluster_zomem_base      = 0x18000000
+        self.cluster_zomem_size      = 0x00020000
+
+        self.cluster_reg_base        = 0x20000000
+        self.cluster_reg_size        = 0x00000200
+
+        #Spatz Vector Unit
+        self.spatz_attaced_core_list = []
+        self.spatz_num_vlsu_port     = 8
+        self.spatz_num_function_unit = 8
+
+        #RedMule
+        self.redmule_ce_height       = 128
+        self.redmule_ce_width        = 32
+        self.redmule_ce_pipe         = 3
+        self.redmule_elem_size       = 2
+        self.redmule_queue_depth     = 1
+        self.redmule_reg_base        = 0x20020000
+        self.redmule_reg_size        = 0x00000200
+
+        #IDMA
+        self.idma_outstand_txn       = 16
+        self.idma_outstand_burst     = 256
+
+        #HBM
+        self.hbm_start_base          = 0xc0000000
+        self.hbm_node_addr_space     = 0x00200000
+        self.num_node_per_ctrl       = 1
+        self.hbm_chan_placement      = [0,0,0,0]
+
+        #NoC
+        self.noc_outstanding         = 64
+        self.noc_link_width          = 512
+
+        #System
+        self.instruction_mem_base    = 0x80000000
+        self.instruction_mem_size    = 0x00010000
+
+        self.soc_register_base       = 0x90000000
+        self.soc_register_size       = 0x00010000
+        self.soc_register_eoc        = 0x90000000
+        self.soc_register_wakeup     = 0x90000004
+
+        #Synchronization
+        self.sync_base               = 0x40000000
+        self.sync_interleave         = 0x00000080
+        self.sync_special_mem        = 0x00000040

--- a/soft_hier/flex_cluster/flex_cluster_arch.py
+++ b/soft_hier/flex_cluster/flex_cluster_arch.py
@@ -32,6 +32,9 @@ class FlexClusterArch:
         self.cluster_tcdm_size       = 0x00100000
         self.cluster_tcdm_remote     = 0x30000000
 
+        self.cluster_heap_base       = 0x00000100
+        self.cluster_heap_end        = 0x00100000
+
         self.cluster_stack_base      = 0x10000000
         self.cluster_stack_size      = 0x00020000
 

--- a/soft_hier/flex_cluster_sdk/runtime/include/flex_alloc.h
+++ b/soft_hier/flex_cluster_sdk/runtime/include/flex_alloc.h
@@ -1,0 +1,306 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Authors: Bowen Wang    <bowwang@iis.ee.ethz.ch>
+//          Gua Hao Khov, ETH Zurich
+
+/*
+Dynamic memory allocation based on linked list of free memory blocks
+*/
+
+#ifndef _FLEX_ALLOC_H_
+#define _FLEX_ALLOC_H_
+
+#include <stdint.h>
+#include "flex_printf.h"
+#include "flex_cluster_arch.h"
+
+/*
+Desc: Free-memory-block indicator
+@var: (unit32_t)               size -- capacity of the free memory block (in bytes)
+@var: (struct alloc_block_s *) next -- pointer to the next free memory block
+*/
+typedef struct alloc_block_s {
+  uint32_t size;
+  struct alloc_block_s *next;
+} alloc_block_t;
+
+/*
+Desc: Allocator data structure
+@var: (alloc_block_t *) first block -- pointer to the first free memory block 
+*/
+typedef struct {
+  alloc_block_t *first_block;
+} alloc_t;
+
+
+/********************
+*  Initialization   *
+********************/
+
+// Initialize the first free-memory-block indicator, and set up the pointer in the allocator
+void flex_cluster_alloc_init(alloc_t *alloc, void *base, const uint32_t size);
+
+/***************
+*  Allocation  *
+***************/
+
+// Memory alllocation with programmer-specified allocator
+void *domain_malloc(alloc_t *alloc, const uint32_t size);
+
+// Memory allocation with default l1 heap allocator
+void *flex_l1_malloc(const uint32_t size);
+
+
+/******************
+*  De-allocation  *
+******************/
+
+// De-allocation with programmer-specified allocator
+void domain_free(alloc_t *alloc, void *const ptr);
+
+// De-allocation with default l1 heap allocator
+void flex_l1_free(void *const ptr);
+
+/*********************
+*  Helper functions  *
+*********************/
+
+// Return the address of the default l1 heap allocator
+alloc_t *flex_get_allocator_l1();
+
+// [debug] print all free-memory-blocks in l1 heap
+void flex_dump_heap();
+
+
+
+/********************
+*  Implementations  *
+********************/
+
+// Block Alignment
+#define MIN_BLOCK_SIZE (uint32_t)sizeof(alloc_block_t)
+
+// Alignment functions (size must be a power of 2)
+#define ALIGN_UP(addr, size) ((addr + size - 1) & ~(size - 1))
+#define ALIGN_DOWN(addr, size) (addr & ~(size - 1))
+
+// Allocator
+// TODO: currently placed at a selected address
+volatile alloc_t * alloc_l1 = (alloc_t *) 0x00000000;
+
+
+/*
+ Canary System based on LSBs of block pointer   
+ |     size     |  canary  |                    
+ |    24-bit    |   8-bit  |                    
+*/
+
+typedef struct {
+  uint32_t size;
+  uint8_t canary;
+} canary_and_size_t;
+
+static inline uint8_t canary(const void *const ptr) {
+  return (uint32_t)ptr & 0xFF;
+}
+
+static inline uint32_t canary_encode(const void *const ptr,
+                                     const uint32_t size) {
+  return (size << 8) | canary(ptr);
+}
+
+static inline canary_and_size_t canary_decode(const uint32_t value) {
+  return (canary_and_size_t){.canary = value & 0xFF, .size = value >> 8};
+}
+
+
+
+/********************
+*  Initialization   *
+********************/
+
+void flex_cluster_alloc_init(alloc_t *alloc, void *base, const uint32_t size) {
+  // Create first block at base address aligned up
+  uint32_t aligned_base = ALIGN_UP((uint32_t)base, MIN_BLOCK_SIZE);
+  alloc_block_t *block_ptr = (alloc_block_t *)aligned_base;
+
+  // Calculate block size aligned down
+  uint32_t block_size = size - ((uint32_t)block_ptr - (uint32_t)base);
+  block_size = ALIGN_DOWN(block_size, MIN_BLOCK_SIZE);
+
+  // Setup allocator
+  block_ptr->size = block_size;
+  block_ptr->next = NULL;
+  alloc->first_block = block_ptr;
+}
+
+
+
+/***********************
+*  Memory Allocation   *
+***********************/
+
+static void *allocate_memory(alloc_t *alloc, const uint32_t size) {
+  // Get first block of linked list of free blocks
+  alloc_block_t *curr = alloc->first_block;
+  alloc_block_t *prev = 0;
+
+  // Search first block large enough in linked list
+  while (curr && (curr->size < size)) {
+    prev = curr;
+    curr = curr->next;
+  }
+
+  if (curr) {
+    // Update allocator
+    if (curr->size == size) {
+      // Special case: Whole block taken
+      if (prev) {
+        prev->next = curr->next;
+      } else {
+        alloc->first_block = curr->next;
+      }
+    } else {
+      // Regular case: Split off block
+      alloc_block_t *new_block = (alloc_block_t *)((char *)curr + size);
+      new_block->size = curr->size - size;
+      new_block->next = curr->next;
+      if (prev) {
+        prev->next = new_block;
+      } else {
+        alloc->first_block = new_block;
+      }
+    }
+
+    // Return block pointer
+    return (void *)curr;
+  } else {
+    // There is no free block large enough
+    return NULL;
+  }
+}
+
+
+void *domain_malloc(alloc_t *alloc, const uint32_t size) {
+  // Calculate actually required block size
+  uint32_t data_size = size + sizeof(uint32_t); // add size/metadata
+  uint32_t block_size = ALIGN_UP(data_size, MIN_BLOCK_SIZE); // add alignment
+
+  // 32-bit metadata = 8-bit canary + 24-bit size
+  // i.e. max allowed block_size == (2^24 - 1) bytes
+  if (block_size >= (1 << (sizeof(uint32_t) * 8 - sizeof(uint8_t) * 8))) {
+    printf("Memory allocator: Requested memory exceeds max block size\n");
+    return NULL;
+  }
+
+  // Allocate memory
+  void *block_ptr = allocate_memory(alloc, block_size);
+  if (!block_ptr) {
+    printf("Memory allocator: No large enough block found (%d)\n", block_size);
+    return NULL;
+  }
+
+  // Store canary and size into first four bytes
+  *((uint32_t *)block_ptr) = canary_encode(block_ptr, block_size);
+
+  // Return data pointer
+  void *data_ptr = (void *)((uint32_t *)block_ptr + 1);
+  return data_ptr;
+}
+
+
+void *flex_l1_malloc(const uint32_t size) {
+  return domain_malloc(alloc_l1, size);
+}
+
+
+
+
+/*******************
+*  De-allocation   *
+*******************/
+
+static void free_memory(alloc_t *alloc, void *const ptr, const uint32_t size) {
+  alloc_block_t *block_ptr = (alloc_block_t *)ptr;
+  // Get first block of linked list of free blocks
+  alloc_block_t *next = alloc->first_block;
+  alloc_block_t *prev = 0;
+
+  // Find position in linked list of free blocks
+  while (next && next < block_ptr) {
+    prev = next;
+    next = next->next;
+  }
+
+  // Connect with next block
+  if (((char *)block_ptr + size) == (char *)next) {
+    // Special case: Coalesce with adjacent next block
+    block_ptr->size = size + next->size;
+    block_ptr->next = next->next;
+  } else {
+    // Regular case: Link to next block
+    block_ptr->size = size;
+    block_ptr->next = next;
+  }
+
+  if (prev) {
+    // Connect with previous block
+    if (((char *)prev + prev->size) == (char *)block_ptr) {
+      // Special case: Coalesce with adjacent previous block
+      prev->size += block_ptr->size;
+      prev->next = block_ptr->next;
+    } else {
+      // Regular case: Link from previous block
+      prev->next = block_ptr;
+    }
+  } else {
+    alloc->first_block = block_ptr;
+  }
+}
+
+void domain_free(alloc_t *alloc, void *const ptr) {
+  // Get block pointer from data pointer
+  void *block_ptr = (void *)((uint32_t *)ptr - 1);
+
+  // Retrieve canary and size
+  const canary_and_size_t canary_and_size =
+      canary_decode(*(const uint32_t *)block_ptr);
+
+  // Check for memory overflow
+  if (canary_and_size.canary != canary(block_ptr)) {
+    printf("Memory Overflow at %p\n", block_ptr);
+    return;
+  }
+
+  // Free memory
+  free_memory(alloc, block_ptr, canary_and_size.size);
+}
+
+void flex_l1_free(void *const ptr) { domain_free(alloc_l1, ptr); }
+
+
+
+/**********************
+*  Helper functions   *
+**********************/
+
+alloc_t *flex_get_allocator_l1() { return alloc_l1; }
+
+
+
+void flex_dump_heap(){
+  // access the first free-memory-block indicator
+  alloc_block_t *curr = alloc_l1->first_block;
+  uint32_t block_id = 0; // for printing
+
+  printf("Memory allocator: Free-memory-block dump\n");
+  while (curr) {
+  	printf("[block_id %d] addr: 0x%x, size (byte): %d\n", block_id, (uint32_t)curr, curr->size);
+    curr = curr->next;
+    block_id += 1;
+  }
+}
+
+#endif

--- a/soft_hier/flex_cluster_sdk/runtime/include/flex_alloc.h
+++ b/soft_hier/flex_cluster_sdk/runtime/include/flex_alloc.h
@@ -297,10 +297,11 @@ void flex_dump_heap(){
 
   printf("Memory allocator: Free-memory-block dump\n");
   while (curr) {
-  	printf("[block_id %d] addr: 0x%x, size (byte): %d\n", block_id, (uint32_t)curr, curr->size);
+  	printf("[block_id %d] addr: 0x%08x, size (byte): %x\n", block_id, (uint32_t)curr, curr->size);
     curr = curr->next;
     block_id += 1;
   }
+  printf("\n");
 }
 
 #endif

--- a/soft_hier/flex_cluster_sdk/runtime/include/flex_alloc.h
+++ b/soft_hier/flex_cluster_sdk/runtime/include/flex_alloc.h
@@ -212,7 +212,7 @@ void *domain_malloc(alloc_t *alloc, const uint32_t size) {
 
 
 void *flex_l1_malloc(const uint32_t size) {
-  return domain_malloc(alloc_l1, size);
+  return domain_malloc((alloc_t *)alloc_l1, size);
 }
 
 
@@ -278,7 +278,7 @@ void domain_free(alloc_t *alloc, void *const ptr) {
   free_memory(alloc, block_ptr, canary_and_size.size);
 }
 
-void flex_l1_free(void *const ptr) { domain_free(alloc_l1, ptr); }
+void flex_l1_free(void *const ptr) { domain_free((alloc_t *)alloc_l1, ptr); }
 
 
 
@@ -286,7 +286,7 @@ void flex_l1_free(void *const ptr) { domain_free(alloc_l1, ptr); }
 *  Helper functions   *
 **********************/
 
-alloc_t *flex_get_allocator_l1() { return alloc_l1; }
+alloc_t *flex_get_allocator_l1() { return (alloc_t *)alloc_l1; }
 
 
 

--- a/soft_hier/flex_cluster_sdk/runtime/include/flex_runtime.h
+++ b/soft_hier/flex_cluster_sdk/runtime/include/flex_runtime.h
@@ -103,6 +103,12 @@ uint32_t flex_is_first_core(){
 *  Data Allocation  *
 ********************/
 
+// Back-adaptation for other config fills to pass CI
+#ifndef ARCH_CLUSTER_HEAP_BASE
+#define ARCH_CLUSTER_HEAP_BASE (0x00000000)
+#define ARCH_CLUSTER_HEAP_END  (0x00000000)
+#endif
+
 /*
  * Desc: cluster-private heap allocator initialization
  */

--- a/soft_hier/flex_cluster_sdk/runtime/include/flex_runtime.h
+++ b/soft_hier/flex_cluster_sdk/runtime/include/flex_runtime.h
@@ -2,6 +2,7 @@
 #define _FLEX_RUNTIME_H_
 #include <stdint.h>
 #include "flex_cluster_arch.h"
+#include "flex_alloc.h"
 
 #define ARCH_NUM_CLUSTER            (ARCH_NUM_CLUSTER_X*ARCH_NUM_CLUSTER_Y)
 #define cluster_index(x,y)          ((y)*ARCH_NUM_CLUSTER_X+(x))
@@ -96,6 +97,23 @@ uint32_t flex_is_first_core(){
     uint32_t hartid;
     asm volatile("csrr %0, mhartid" : "=r"(hartid));
     return (hartid == 0);
+}
+
+/********************
+*  Data Allocation  *
+********************/
+
+/*
+ * Desc: cluster-private heap allocator initialization
+ */
+
+void flex_alloc_init(){
+    volatile uint32_t * heap_start      = (volatile uint32_t *) ARCH_CLUSTER_HEAP_BASE;
+    volatile uint32_t * heap_end        = (volatile uint32_t *) ARCH_CLUSTER_HEAP_END;
+    volatile uint32_t   heap_size       = (uint32_t)heap_end - (uint32_t)heap_start;
+    if (flex_is_first_core()){
+        flex_cluster_alloc_init(flex_get_allocator_l1(), (void *)heap_start, heap_size);
+    }
 }
 
 /*******************


### PR DESCRIPTION
## 🛠️ Modification

<!-- Describe what this PR changes and why -->
- Implemented basic memory allocation support in the Flex cluster runtime: 
  - `flex_cluster_alloc_init()`: allocator initialization
  - `flex_malloc_l1()`: memory allocation within L1 heap
  - `flex_l1_free()`: memory de-allocation within L1 heap
- Integrated `ARCH_CLUSTER_HEAP_BASE` and `ARCH_CLUSTER_HEAP_END` to define heap range
  - Added in `flex_cluster_arch.py` 
- Basic memory allocation test implementation
  - Added in `hello_world.h` as `test_malloc_single_cluster()`

## ⚠️ Known Limitations

<!-- Call out anything that’s not complete, hardcoded, or to be improved later -->
- Assumes single allocator per cluster
- **(TODO)** support on globally visible memory allocation 
- **(TODO)** support on cross-cluster allocation with identical start address to facilitate broadcast

## ✅ How to Test

<!-- Provide steps to verify the functionality -->
1. Change `examples/SoftHier/software/test/main.c`
    ```c
    // hello_world_all_core();
    test_malloc_single_cluster();
    ```
2. Compile and run:
   ```bash
   cfg=examples/SoftHier/config/arch_malloc_check.py app=examples/SoftHier/software/test make hs; make run