### PR TITLE
[vlsu] configurable bus width

### DIFF
--- a/examples/SoftHier/config/arch_spatz_check.py
+++ b/examples/SoftHier/config/arch_spatz_check.py
@@ -44,7 +44,8 @@ class FlexClusterArch:
         #Spatz Vector Unit
         self.spatz_attaced_core_list = [0]
         self.spatz_num_vlsu_port     = 4
-        self.spatz_num_function_unit = 1
+        self.spatz_num_function_unit = 4
+        self.spatz_vlsu_port_width   = 32
 
         #RedMule
         self.redmule_ce_height       = 128

--- a/soft_hier/flex_cluster/cluster_unit.py
+++ b/soft_hier/flex_cluster/cluster_unit.py
@@ -79,6 +79,7 @@ class ClusterArch:
                         idma_outstand_txn,  idma_outstand_burst,
                         num_cluster_x,      num_cluster_y,
                         spatz_core_list,    spatz_num_vlsu,     spatz_num_fu,
+                        spatz_vlsu_bw,
                         data_bandwidth,     auto_fetch=False,   multi_idma_enable=0):
 
         self.nb_core                = nb_core_per_cluster
@@ -97,6 +98,7 @@ class ClusterArch:
         self.spatz_core_list        = spatz_core_list
         self.spatz_num_vlsu         = spatz_num_vlsu
         self.spatz_num_fu           = spatz_num_fu
+        self.spatz_vlsu_bw          = spatz_vlsu_bw
 
         #RedMule
         self.redmule_ce_height      = redmule_ce_height
@@ -223,11 +225,11 @@ class ClusterUnit(gvsoc.systree.Component):
         for core_id in range(0, arch.nb_core):
             cores.append(iss.Snitch(self, f'pe{core_id}', isa='rv32imfdva',
                 fetch_enable=arch.auto_fetch, boot_addr=boot_addr,
-                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu))
+                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu, spatz_vlsu_bw=arch.spatz_vlsu_bw))
 
             fp_cores.append(iss.Snitch_fp_ss(self, f'fp_ss{core_id}', isa='rv32imfdva',
                 fetch_enable=arch.auto_fetch, boot_addr=boot_addr,
-                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu))
+                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu, spatz_vlsu_bw=arch.spatz_vlsu_bw))
             if xfrep:
                 fpu_sequencers.append(Sequencer(self, f'fpu_sequencer{core_id}', latency=0))
 

--- a/soft_hier/flex_cluster/flex_cluster.py
+++ b/soft_hier/flex_cluster/flex_cluster.py
@@ -129,6 +129,7 @@ class FlexClusterSystem(gvsoc.systree.Component):
                                         spatz_core_list     =   arch.spatz_attaced_core_list,
                                         spatz_num_vlsu      =   arch.spatz_num_vlsu_port,
                                         spatz_num_fu        =   arch.spatz_num_function_unit,
+                                        spatz_vlsu_bw       =   arch.spatz_vlsu_port_width if hasattr(arch, 'spatz_vlsu_port_width') else 32,
                                         data_bandwidth      =   arch.noc_link_width/8,
                                         multi_idma_enable   =   1 if hasattr(arch, 'multi_idma_enable') else 0)
             cluster_list.append(ClusterUnit(self,f'cluster_{cluster_id}', cluster_arch, binary))

--- a/soft_hier/gvsoc_core.patch
+++ b/soft_hier/gvsoc_core.patch
@@ -768,7 +768,7 @@ index 84e01c06..cadf5f31 100644
      IssOffloadInsn<iss_reg_t> offload_insn = {
          .opcode=insn->opcode,
 diff --git a/models/cpu/iss/include/isa_lib/vint.h b/models/cpu/iss/include/isa_lib/vint.h
-index 26cb748e..17843015 100644
+index 26cb748e..f8c14e0f 100644
 --- a/models/cpu/iss/include/isa_lib/vint.h
 +++ b/models/cpu/iss/include/isa_lib/vint.h
 @@ -31,6 +31,12 @@
@@ -784,15 +784,18 @@ index 26cb748e..17843015 100644
  
  #pragma STDC FENV_ACCESS ON
  
-@@ -93,6 +99,7 @@
+@@ -93,7 +99,9 @@
  #define LMUL iss->spatz.LMUL_t
  #define VL iss->csr.vl.value
  #define VSTART iss->csr.vstart.value
+-
 +#define NUM_FPU (CONFIG_GVSOC_ISS_SPATZ_FPU  * ((64 + SEW - 1) / (SEW)))
- 
++// bowwang: high-level parameter defines VLSU-L1 bus width
++#define INTF_WIDTH (CONFIG_GVSOC_ISS_SPATZ_VLSU_BW/8)
  
  static inline void printBin(int size, bool *a,const char name[]){
-@@ -116,7 +123,8 @@ static inline void printHex(int size, bool *a,const char name[]){
+     printf("%s = ",name);
+@@ -116,7 +124,8 @@ static inline void printHex(int size, bool *a,const char name[]){
  static inline int  bin8ToChar(bool *bin,int s, int e){
      int c = 0;
      for(int i = s; i < e;i++){
@@ -802,7 +805,7 @@ index 26cb748e..17843015 100644
      }
      return c;
  }
-@@ -270,7 +278,8 @@ static inline void buildDataInt(Iss *iss, int vs, int i, int64_t* data){
+@@ -270,7 +279,8 @@ static inline void buildDataInt(Iss *iss, int vs, int i, int64_t* data){
      }
      *data = 0;
      for(int j = 0;j < iteration;j++){
@@ -812,7 +815,7 @@ index 26cb748e..17843015 100644
      }
  }
  
-@@ -300,7 +309,8 @@ static inline void myAbs(Iss *iss, int size, int vs, int i, int64_t* data){
+@@ -300,7 +310,8 @@ static inline void myAbs(Iss *iss, int size, int vs, int i, int64_t* data){
  
      *data = 0;
      for(int j = 0;j < iteration;j++){
@@ -822,7 +825,7 @@ index 26cb748e..17843015 100644
      }
      *data += cin;
      *data = cin?(-*data):*data;
-@@ -316,21 +326,23 @@ static inline void myAbsU(Iss *iss,int size, int vs, int i, uint64_t* data){
+@@ -316,21 +327,23 @@ static inline void myAbsU(Iss *iss,int size, int vs, int i, uint64_t* data){
  
      *data = 0;
      for(int j = 0;j < iteration;j++){
@@ -849,21 +852,21 @@ index 26cb748e..17843015 100644
      }
  }
  
-@@ -582,9 +594,44 @@ INLINE void ff_sgnj(flexfloat_t *dest, const flexfloat_t *a,const flexfloat_t *b
+@@ -582,9 +595,44 @@ INLINE void ff_sgnj(flexfloat_t *dest, const flexfloat_t *a,const flexfloat_t *b
  }
  
  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 +static inline void lib_VIDV    (Iss *iss, int vs2, int64_t rs1, int vd, bool vm){
-+
+ 
 +    for (int i = VSTART; i < VL; i++){
 +
 +        int32_t val = i;
 +        bool resBin[64];
- 
++
 +        intToBin(SEW, abs(val), resBin);
 +
 +        writeToVReg(iss, SEW, vd, i, resBin);
-+
+ 
 +    }
 +}
  
@@ -871,7 +874,7 @@ index 26cb748e..17843015 100644
 +    int64_t data1, data2, res;
 +    bool bin[8];
 +    bool resBin[64];
- 
++
 +    for (int i = VSTART; i < VL; i++){
 +        if(!(i%8)){
 +            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
@@ -894,7 +897,7 @@ index 26cb748e..17843015 100644
  
  
  static inline void lib_ADDVV    (Iss *iss, int vs1, int vs2    , int vd, bool vm){
-@@ -3418,6 +3465,56 @@ static inline void lib_FADDVF   (Iss *iss, int vs2, int64_t rs1, int vd, bool vm
+@@ -3418,6 +3466,56 @@ static inline void lib_FADDVF   (Iss *iss, int vs2, int64_t rs1, int vd, bool vm
      }
  }
  
@@ -951,7 +954,7 @@ index 26cb748e..17843015 100644
  static inline void lib_FSUBVV   (Iss *iss, int vs1,     int vs2, int vd, bool vm){
      bool bin[8];
      unsigned long int res, data1, data2;
-@@ -3591,6 +3688,55 @@ static inline void lib_FMAXVF   (Iss *iss, int vs2, int64_t rs1, int vd, bool vm
+@@ -3591,6 +3689,55 @@ static inline void lib_FMAXVF   (Iss *iss, int vs2, int64_t rs1, int vd, bool vm
      }
  }
  
@@ -1007,7 +1010,7 @@ index 26cb748e..17843015 100644
  static inline void lib_FMULVV   (Iss *iss, int vs1,     int vs2, int vd, bool vm){
      bool bin[8];
      unsigned long int res, data1, data2;
-@@ -4170,6 +4316,30 @@ static inline void lib_FREDMAXVS(Iss *iss, int vs1,     int vs2, int vd, bool vm
+@@ -4170,6 +4317,30 @@ static inline void lib_FREDMAXVS(Iss *iss, int vs1,     int vs2, int vd, bool vm
      writeToVReg(iss, SEW, vd, 0, resBin);
  }
  
@@ -1038,7 +1041,7 @@ index 26cb748e..17843015 100644
  static inline void lib_FREDMINVS(Iss *iss, int vs1,     int vs2, int vd, bool vm){
      bool bin[8];
      unsigned long int res, data1, data2;
-@@ -4221,6 +4391,32 @@ static inline void lib_FREDSUMVS(Iss *iss, int vs1,     int vs2, int vd, bool vm
+@@ -4221,6 +4392,32 @@ static inline void lib_FREDSUMVS(Iss *iss, int vs1,     int vs2, int vd, bool vm
      writeToVReg(iss, SEW, vd, 0, resBin);
  }
  
@@ -1071,16 +1074,27 @@ index 26cb748e..17843015 100644
  static inline void lib_FWADDVV  (Iss *iss, int vs1,     int vs2, int vd, bool vm){
      bool bin[8];
      unsigned long int res, data1, data2;
-@@ -5584,8 +5780,6 @@ inline void Vlsu::handle_pending_io_access(Iss *iss)
+@@ -5582,10 +5779,8 @@ inline void Vlsu::handle_pending_io_access(Iss *iss)
+         vp::IoReq *req = &this->io_req;
+ 
          uint32_t addr = this->io_pending_addr;        
-         uint32_t addr_aligned = addr & ~(4 - 1);
-         int size = addr_aligned + 4 - addr;
+-        uint32_t addr_aligned = addr & ~(4 - 1);
+-        int size = addr_aligned + 4 - addr;
 -        // printf("size = %d\n" , size);
 -        // printf("io_pending_size = %d\n" , this->io_pending_size);        
++        uint32_t addr_aligned = addr & ~(INTF_WIDTH - 1);
++        int size = addr_aligned + INTF_WIDTH - addr;
          if (size > this->io_pending_size){
              size = this->io_pending_size;
          }
-@@ -5600,9 +5794,10 @@ inline void Vlsu::handle_pending_io_access(Iss *iss)
+@@ -5595,14 +5790,17 @@ inline void Vlsu::handle_pending_io_access(Iss *iss)
+         req->set_size(size);
+         req->set_is_write(this->io_pending_is_write);
+         req->set_data(this->io_pending_data);
++        // bowwang: debug information
++        printf("[vlsu %d] addr: 0x%08x, size: %d\n", this->next_io, addr, size);
+ 
+         this->io_pending_data += size;
          this->io_pending_size -= size;
          this->io_pending_addr += size;
  
@@ -1093,7 +1107,7 @@ index 26cb748e..17843015 100644
          }
          else if (err == vp::IO_REQ_INVALID){
              this->waiting_io_response = false;
-@@ -5611,6 +5806,9 @@ inline void Vlsu::handle_pending_io_access(Iss *iss)
+@@ -5611,6 +5809,9 @@ inline void Vlsu::handle_pending_io_access(Iss *iss)
          else{
  
          }
@@ -1103,7 +1117,754 @@ index 26cb748e..17843015 100644
      }
      else{
          this->waiting_io_response = false;
-@@ -6943,6 +7141,7 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
+@@ -5620,66 +5821,35 @@ inline void Vlsu::handle_pending_io_access(Iss *iss)
+ 
+ static inline void lib_VLE8V (Iss *iss, iss_reg_t rs1, int vd , bool vm){
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
++    uint8_t data[INTF_WIDTH];
+     // printf("VLE8\n");
+     // printf("vd = %d\n",vd);
+     // printf("VSTART = %ld\n",VSTART);
+     // printf("vl = %ld\n",VL);
+     // printf("RS1 = %lx\n",rs1);
+ 
+-
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][VSTART+2] = data[2];
+-
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, false);
++        for (int i = 0; i < count; ++i) {
++            iss->spatz.vregfile.vregs[vd][VSTART + i] = data[i];
++        }
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+ 
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL; i+=INTF_WIDTH){
+ 
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH,data,false);
+ 
++        for (int j=0; j<INTF_WIDTH; j++){
++            iss->spatz.vregfile.vregs[vd][i+j] = data[j];
++        }
+ 
+-
+-
+-    for (int i = VSTART+align; i < VL; i+=4){
+- //       if(!i){
+- //           printf("Vlsu_io_access\n");
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+- //       }else{
+- //           printf("handle_pending_io_access\n");
+- //           vlsu.handle_pending_io_access(iss);
+- //       }
+-
+-        // printf("data0 = %x\n",data[0]);
+-        // printf("data1 = %x\n",data[1]);
+-        // printf("data2 = %x\n",data[2]);
+-        // printf("data3 = %x\n",data[3]);
+-
+-        iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][i+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][i+2] = data[2];
+-        iss->spatz.vregfile.vregs[vd][i+3] = data[3];
+-
+-        start_add += 4;
++        start_add += INTF_WIDTH;
+     }
+ }
+ 
+@@ -5693,67 +5863,43 @@ static inline void lib_VLE16V(Iss *iss, iss_reg_t rs1, int vd , bool vm){
+     // printf("vd = %d\n",vd);
+ 
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
+-
+-
++    uint8_t data[INTF_WIDTH];
+ 
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][VSTART+2] = data[2];
+-
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, false);
++        for (int i = 0; i < count; ++i) {
++            iss->spatz.vregfile.vregs[vd][VSTART + i] = data[i];
++        }
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+ 
+-    for (int i = VSTART+align; i < VL*2; i+=4){
+-        //if(!i){
+-            //vlsu.Vlsu_io_access(iss, rs1, vlEN/8, data, false);
+-            iss->spatz.vlsu.Vlsu_io_access(iss, start_add, 4, data, false);
+-        //}else{
+-        //    vlsu.handle_pending_io_access(iss);
+-        //}
+-
+-        // printf("data0 = %d\n",data[0]);
+-        // printf("data1 = %d\n",data[1]);
+-        // printf("data2 = %d\n",data[2]);
+-        // printf("data3 = %d\n",data[3]);
+-
+-        // printf("vd = %d\n",vd);
+-
+-        //iss->spatz.vregfile.vregs[vd][i+0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? (data[1]*pow(2,8) + data[0]) : iss->spatz.vregfile.vregs[vd][i+0];
+-        //iss->spatz.vregfile.vregs[vd][i+1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? (data[3]*pow(2,8) + data[2]) : iss->spatz.vregfile.vregs[vd][i+1];
++    
++    // bowwang: VL*2: each element is 16-bits (2 bytes)
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
++        // after aligned, each request width == bus width
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, false);
++        
++        for (int j=0; j<INTF_WIDTH; j++){
++            iss->spatz.vregfile.vregs[vd][i+j] = data[j];
++        }
+ 
+-        // iss->spatz.vregfile.vregs[vd][i+0] = (data[1]*pow(2,8) + data[0]);
+-        // iss->spatz.vregfile.vregs[vd][i+1] = (data[3]*pow(2,8) + data[2]);
++        start_add += INTF_WIDTH;
++    }
+ 
+-        iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][i+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][i+2] = data[2];
+-        iss->spatz.vregfile.vregs[vd][i+3] = data[3];
++    // bowwang: register check
++    // for (int i=VSTART; i < VL*2; i+=INTF_WIDTH){
++    //     printf("reg dump:\n 0x");
++    //     for (int j=0; j<INTF_WIDTH; j++){
++    //         printf("%2x_", iss->spatz.vregfile.vregs[vd][i+j]);
++    //     }
++    //     printf("\n");
++    // }
+ 
+-        // printf("vd_vali = %d\n",(int)(data[1]*pow(2,8) + data[0]));
+-        // printf("vd_vali+1 = %d\n",(int)(data[3]*pow(2,8) + data[2]));
+-        start_add += 4;
+-    }
+ }
+ 
+ static inline void lib_VLE32V(Iss *iss, iss_reg_t rs1, int vd , bool vm){
+@@ -5766,72 +5912,31 @@ static inline void lib_VLE32V(Iss *iss, iss_reg_t rs1, int vd , bool vm){
+     // printf("vd = %d\n",vd);
+ 
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
++    uint8_t data[INTF_WIDTH];
+ 
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][VSTART+2] = data[2];
+-
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, false);
++        for (int i = 0; i < count; ++i) {
++            iss->spatz.vregfile.vregs[vd][VSTART + i] = data[i];
++        }
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+ 
+ 
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*4; i+=INTF_WIDTH){
+ 
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, false);
+ 
+-    for (int i = VSTART+align; i < VL*4; i+=4){
+-        //if(!i){
+-            //vlsu.Vlsu_io_access(iss, rs1, vlEN/8, data, false);
+-            iss->spatz.vlsu.Vlsu_io_access(iss, start_add, 4, data, false);
+-        //}else{
+-        //    vlsu.handle_pending_io_access(iss);
+-        //}
+-
+-        // printf("data0 = %d\n",data[0]);
+-        // printf("data1 = %d\n",data[1]);
+-        // printf("data2 = %d\n",data[2]);
+-        // printf("data3 = %d\n",data[3]);
+-
+-        //printf("vd = %d\n",vd);
+-
+-        //iss->spatz.vregfile.vregs[vd][i+0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? (data[1]*pow(2,8) + data[0]) : iss->spatz.vregfile.vregs[vd][i+0];
+-        //iss->spatz.vregfile.vregs[vd][i+1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? (data[3]*pow(2,8) + data[2]) : iss->spatz.vregfile.vregs[vd][i+1];
+-
+-        // iss->spatz.vregfile.vregs[vd][i+0] = (data[1]*pow(2,8) + data[0]);
+-        // iss->spatz.vregfile.vregs[vd][i+1] = (data[3]*pow(2,8) + data[2]);
+-
+-        iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][i+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][i+2] = data[2];
+-        iss->spatz.vregfile.vregs[vd][i+3] = data[3];
+-
+-        // printf("vd0 = %d\n",iss->spatz.vregfile.vregs[vd][i+0]);
+-        // printf("vd1 = %d\n",iss->spatz.vregfile.vregs[vd][i+1]);
+-        // printf("vd2 = %d\n",iss->spatz.vregfile.vregs[vd][i+2]);
+-        // printf("vd3 = %d\n",iss->spatz.vregfile.vregs[vd][i+3]);
+-
++        for (int j=0; j<INTF_WIDTH; j++){
++            iss->spatz.vregfile.vregs[vd][i+j] = data[j];
++        }
+ 
+-        // printf("vd_vali = %d\n",(int)(data[3]*pow(2,8*3) + data[2]*pow(2,8*2) + data[1]*pow(2,8) + data[0]));
+-        start_add += 4;
++        start_add += INTF_WIDTH;
+     }
+ }
+ 
+@@ -5845,387 +5950,150 @@ static inline void lib_VLE64V(Iss *iss, iss_reg_t rs1, int vd , bool vm){
+     // printf("vd = %d\n",vd);
+ 
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
++    uint8_t data[INTF_WIDTH];
+ 
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][VSTART+2] = data[2];
+-
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
+-        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, false);
++        for (int i = 0; i < count; ++i) {
++            iss->spatz.vregfile.vregs[vd][VSTART + i] = data[i];
++        }
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+ 
+-    for (int i = VSTART+align; i < VL*8; i+=4){
+-        //if(!i){
+-            //vlsu.Vlsu_io_access(iss, rs1, vlEN/8, data, false);
+-            iss->spatz.vlsu.Vlsu_io_access(iss, start_add, 4, data, false);
+-        //}else{
+-        //    vlsu.handle_pending_io_access(iss);
+-        //}
+-        // printf("LIB_VLE64V\n");
+-
+-        // printf("data0 = %d\n",data[0]);
+-        // printf("data1 = %d\n",data[1]);
+-        // printf("data2 = %d\n",data[2]);
+-        // printf("data3 = %d\n",data[3]);
+-
+-        //printf("vd = %d\n",vd);
+-
+-        //iss->spatz.vregfile.vregs[vd][i+0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? (data[1]*pow(2,8) + data[0]) : iss->spatz.vregfile.vregs[vd][i+0];
+-        //iss->spatz.vregfile.vregs[vd][i+1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? (data[3]*pow(2,8) + data[2]) : iss->spatz.vregfile.vregs[vd][i+1];
+-
+-        // iss->spatz.vregfile.vregs[vd][i+0] = (data[1]*pow(2,8) + data[0]);
+-        // iss->spatz.vregfile.vregs[vd][i+1] = (data[3]*pow(2,8) + data[2]);
+-
+-        iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-        iss->spatz.vregfile.vregs[vd][i+1] = data[1];
+-        iss->spatz.vregfile.vregs[vd][i+2] = data[2];
+-        iss->spatz.vregfile.vregs[vd][i+3] = data[3];
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
+ 
+-        // printf("vd0 = %d\n",iss->spatz.vregfile.vregs[vd][i+0]);
+-        // printf("vd1 = %d\n",iss->spatz.vregfile.vregs[vd][i+1]);
+-        // printf("vd2 = %d\n",iss->spatz.vregfile.vregs[vd][i+2]);
+-        // printf("vd3 = %d\n",iss->spatz.vregfile.vregs[vd][i+3]);
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, false);
+ 
++        for (int j=0; j<INTF_WIDTH; j++){
++            iss->spatz.vregfile.vregs[vd][i+j] = data[j];
++        }
+ 
+-        // printf("vd_vali = %d\n",(int)(data[3]*pow(2,8*3) + data[2]*pow(2,8*2) + data[1]*pow(2,8) + data[0]));
+-        start_add += 4;
++        start_add += INTF_WIDTH;
+     }
+ }
+ 
+ static inline void lib_VSE8V (Iss *iss, iss_reg_t rs1, int vs3, bool vm){
+-    uint8_t data[4];
++    uint8_t data[INTF_WIDTH];
+     //printf("rs1  = %lu\n",rs1);
+     // printf("vd  = %d\n",vs3);
+ 
+     uint64_t start_add = rs1;
+ 
+-
+-
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][VSTART+2];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        for (int i = 0; i < count; ++i) {
++            data[i]  = iss->spatz.vregfile.vregs[vs3][VSTART+i];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, true);
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+ 
+ 
+ 
+-    for (int i = VSTART+align; i < VL; i+=4){
+-/*
+-        data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
+-        data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+2]%2)) ? iss->spatz.vregfile.vregs[vs3][i+2] : 0;
+-        data[3] = (vm || !(iss->spatz.vregfile.vregs[0][i+3]%2)) ? iss->spatz.vregfile.vregs[vs3][i+3] : 0;
+-*/
+-        // data[3] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
+-        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+2]%2)) ? iss->spatz.vregfile.vregs[vs3][i+2] : 0;
+-        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+3]%2)) ? iss->spatz.vregfile.vregs[vs3][i+3] : 0;
+-
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
+-        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
+-
+-
+-        // printf("STORE8 \n");
+-        // printf("data0  = %d\n",data[0 ]);
+-        // printf("data1  = %d\n",data[1 ]);
+-        // printf("data2  = %d\n",data[2 ]);
+-        // printf("data3  = %d\n",data[3 ]);
+-
+-        // printf("addr  = %lu\n",start_add);
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL; i+=INTF_WIDTH){
+ 
+-        //if(!i){
+-            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        //}else{
+-        //    vlsu.handle_pending_io_access(iss);
+-        //}
+-        start_add += 4;
++        for (int j=0; j<INTF_WIDTH; j++){
++            data[j]  = iss->spatz.vregfile.vregs[vs3][i+j];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH,data,true);
++        start_add += INTF_WIDTH;
+     }
+ }
+ 
+ static inline void lib_VSE16V(Iss *iss, iss_reg_t rs1, int vs3, bool vm){
+-    uint8_t data[4];
++    uint8_t data[INTF_WIDTH];
+     //printf("rs1  = %lu\n",rs1);
+ 
+     uint64_t start_add = (uint64_t)rs1;    
+ 
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][VSTART+2];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        for (int i = 0; i < count; ++i) {
++            data[i]  = iss->spatz.vregfile.vregs[vs3][VSTART+i];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, true);
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+-    for (int i = VSTART+align; i < VL*2; i+=4){
+-        /*
+-        data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
+-        */
+-
+-        // data[3] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0]/pow(2,8) : 0;
+-        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1]/pow(2,8) : 0;
+-        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
+-
+-        // if(!i){
+-        //     vlsu.Vlsu_io_access(iss, rs1,vlEN/8,data,true);
+-        // }else{
+-        //     vlsu.handle_pending_io_access(iss);
+-        // }
+-
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
+-        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
+-        // printf("i = %d\t,vd = %d\n",i,vs3);
+-
+-        // printf("STORE16 \n");
+-        // printf("data0  = %d\n",data[0]);
+-        // printf("data1  = %d\n",data[1]);
+-        // printf("data2  = %d\n",data[2]);
+-        // printf("data3  = %d\n",data[3]);
+-
+-        // printf("addr  = %lu\n",start_add);
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
+ 
+-        //if(!i){
+-            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        //}else{
+-        //    vlsu.handle_pending_io_access(iss);
+-        //}
+-        start_add += 4;
++        for (int j=0; j<INTF_WIDTH; j++){
++            data[j]  = iss->spatz.vregfile.vregs[vs3][i+j];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH,data,true);
++        start_add += INTF_WIDTH;
+     }
++
+ }
+ 
+ static inline void lib_VSE32V(Iss *iss, iss_reg_t rs1, int vs3, bool vm){
+-    uint8_t data[4];
++    uint8_t data[INTF_WIDTH];
+     //printf("rs1  = %lu\n",rs1);
+ 
+     uint64_t start_add = rs1;
+ 
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][VSTART+2];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        for (int i = 0; i < count; ++i) {
++            data[i]  = iss->spatz.vregfile.vregs[vs3][VSTART+i];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, true);
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+ 
+ 
+-    for (int i = VSTART+align; i < VL*4; i+=4){
+-        /*
+-        data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
+-        */
+-
+-        // data[3] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0]/pow(2,8) : 0;
+-        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1]/pow(2,8) : 0;
+-        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*4; i+=INTF_WIDTH){
+ 
+-        // if(!i){
+-        //     vlsu.Vlsu_io_access(iss, rs1,vlEN/8,data,true);
+-        // }else{
+-        //     vlsu.handle_pending_io_access(iss);
+-        // }
+-
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
+-        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
+-
+-
+-        // printf("STORE32 \n");
+-        // printf("data0  = %d\n",data[0]);
+-        // printf("data1  = %d\n",data[1]);
+-        // printf("data2  = %d\n",data[2]);
+-        // printf("data3  = %d\n",data[3]);
+-
+-        // printf("addr  = %lu\n",start_add);
+-
+-        //if(!i){
+-            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        //}else{
+-        //    vlsu.handle_pending_io_access(iss);
+-        //}
+-        start_add += 4;
++        for (int j=0; j<INTF_WIDTH; j++){
++            data[j]  = iss->spatz.vregfile.vregs[vs3][i+j];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,INTF_WIDTH,data,true);
++        start_add += INTF_WIDTH;
+     }
+ }
+ 
+ static inline void lib_VSE64V(Iss *iss, iss_reg_t rs1, int vs3, bool vm){
+-    // uint8_t data[vl];
+-    // uint32_t temp;
+-    // for (int i = VSTART; i < VL*2; i+=1){
+-    //     if(i%2){
+-    //         temp = iss->spatz.vregfile.vregs[vs3][i+0]/pow(2,8*4);
+-    //         data[3] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? temp/pow(2,8*3) : 0;
+-    //         data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? temp/pow(2,8*2) : 0;
+-    //         data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? temp/pow(2,8*1) : 0;
+-    //         data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? temp/pow(2,8*0) : 0;
+-    //     }else{
+-    //         temp = iss->spatz.vregfile.vregs[vs3][i+0];
+-    //         data[3] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? temp/pow(2,8*3) : 0;
+-    //         data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? temp/pow(2,8*2) : 0;
+-    //         data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? temp/pow(2,8*1) : 0;
+-    //         data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? temp/pow(2,8*0) : 0;
+-    //     }
+-    //     if(!i){
+-    //         vlsu.Vlsu_io_access(iss, rs1,vlEN/8,data,true);
+-    //     }else{
+-    //         vlsu.handle_pending_io_access(iss);
+-    //     }
+-    // }
+-    uint8_t data[4];
++
++    uint8_t data[INTF_WIDTH];
+     //printf("rs1  = %lu\n",rs1);
+ 
+     uint64_t start_add = rs1;
+ 
+-
+-    int align = 0;
+-    if(start_add%4 == 1){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][VSTART+2];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        
+-        start_add += 3;
+-        align = 3;
+-    }else if(start_add%4 == 2){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][VSTART+1];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 2;
+-        align = 2;        
+-    }else if(start_add%4 == 3){
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][VSTART+0];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-
+-        start_add += 1;
+-        align = 1;
+-    }else{
+-        align = 0;
++    int align = start_add % INTF_WIDTH;
++    if (align != 0) {
++        int count = INTF_WIDTH - align;
++        for (int i = 0; i < count; ++i) {
++            data[i]  = iss->spatz.vregfile.vregs[vs3][VSTART+i];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH, data, true);
++        start_add += count;
++    } else {
++        align = INTF_WIDTH;
+     }
+ 
+-    for (int i = VSTART+align; i < VL*8; i+=4){
+-        /*
+-        data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
+-        */
+-
+-        // data[3] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0]/pow(2,8) : 0;
+-        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
+-        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1]/pow(2,8) : 0;
+-        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
+ 
+-        // if(!i){
+-        //     vlsu.Vlsu_io_access(iss, rs1,vlEN/8,data,true);
+-        // }else{
+-        //     vlsu.handle_pending_io_access(iss);
+-        // }
+-
+-        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
+-        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
+-        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
+-        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
+-
+-
+-        // printf("STORE64 \n");
+-        // printf("data0  = %d\n",data[0]);
+-        // printf("data1  = %d\n",data[1]);
+-        // printf("data2  = %d\n",data[2]);
+-        // printf("data3  = %d\n",data[3]);
+-
+-        // printf("addr  = %lu\n",start_add);
+-
+-        //if(!i){
+-            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
+-        //}else{
+-        //    vlsu.handle_pending_io_access(iss);
+-        //}
+-        start_add += 4;
++        for (int j=0; j<INTF_WIDTH; j++){
++            data[j]  = iss->spatz.vregfile.vregs[vs3][i+j];
++        }
++        iss->spatz.vlsu.Vlsu_io_access(iss, start_add, INTF_WIDTH,data,true);
++        start_add += INTF_WIDTH;
+     }
+ }
+ 
+@@ -6943,6 +6811,7 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
          }else{
              AVL = VL;
          }

--- a/soft_hier/gvsoc_pulp.patch
+++ b/soft_hier/gvsoc_pulp.patch
@@ -1428,10 +1428,10 @@ index 673529f..080f26f 100644
  #include <vp/vp.hpp>
  #include <vp/itf/io.hpp>
 diff --git a/pulp/snitch/snitch_core.py b/pulp/snitch/snitch_core.py
-index 0bda5e4..5bc2d97 100644
+index 0bda5e4..896bb54 100644
 --- a/pulp/snitch/snitch_core.py
 +++ b/pulp/snitch/snitch_core.py
-@@ -86,20 +86,27 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
+@@ -86,20 +86,28 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
      def __init__(self,
              parent,
              name,
@@ -1444,6 +1444,7 @@ index 0bda5e4..5bc2d97 100644
              inc_spatz: bool=False,
 +            spatz_num_vlsu: int=4,
 +            spatz_num_fpu: int=4,
++            spatz_vlsu_bw: int=32,
              core_id: int=0,
              htif: bool=False):
  
@@ -1462,13 +1463,14 @@ index 0bda5e4..5bc2d97 100644
              add_latencies(isa_instance)
              isa_instances[isa] = isa_instance
  
-@@ -146,17 +153,23 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
+@@ -146,17 +154,24 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
              self.add_sources([
                  "cpu/iss/src/spatz.cpp",
              ])
 +            self.add_c_flags(['-DCONFIG_GVSOC_ISS_INC_SPATZ=1'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU={spatz_num_vlsu}'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_FPU={spatz_num_fpu}'])
++            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU_BW={spatz_vlsu_bw}'])
  
      def o_BARRIER_REQ(self, itf: gvsoc.systree.SlaveItf):
          self.itf_bind('barrier_req', itf, signature='wire<bool>')
@@ -1487,7 +1489,7 @@ index 0bda5e4..5bc2d97 100644
              misa: int=None,
              binaries: list=[],
              fetch_enable: bool=False,
-@@ -197,19 +210,26 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
+@@ -197,19 +212,27 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
      def __init__(self,
              parent,
              name,
@@ -1500,6 +1502,7 @@ index 0bda5e4..5bc2d97 100644
              inc_spatz: bool=False,
 +            spatz_num_vlsu: int=4,
 +            spatz_num_fpu: int=4,
++            spatz_vlsu_bw: int=32,
              core_id: int=0,
              timed: bool=False,
              htif: bool=False):
@@ -1518,17 +1521,18 @@ index 0bda5e4..5bc2d97 100644
  
          add_latencies(isa_instance)
  
-@@ -254,6 +274,9 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
+@@ -254,6 +277,10 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
              self.add_sources([
                  "cpu/iss/src/spatz.cpp",
              ])
 +            self.add_c_flags(['-DCONFIG_GVSOC_ISS_INC_SPATZ=1'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU={spatz_num_vlsu}'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_FPU={spatz_num_fpu}'])
++            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU_BW={spatz_vlsu_bw}'])
  
      def o_BARRIER_REQ(self, itf: gvsoc.systree.SlaveItf):
          self.itf_bind('barrier_req', itf, signature='wire<bool>')
-@@ -266,7 +289,7 @@ class Spatz(cpu.iss.riscv.RiscvCommon):
+@@ -266,7 +293,7 @@ class Spatz(cpu.iss.riscv.RiscvCommon):
      def __init__(self,
              parent,
              name,


### PR DESCRIPTION
# Enable configurable Spatz VLSU-L1 Buswidth

## Description
This PR enables a configurable VLSU-to-L1 buswidth in Spatz. It is configured in file `flex_cluster_arch.py` with entry `spatz_vlsu_port_width`.

- If this entry is not specified in the configuration file, the default configuration is 32-bit buswidth.
- This configuration is currently added to `examples/SoftHier/config/arch_spatz_check.py` for testing.
- For verification reasons, a single print function is added to `vint.h` in io_request handler. It can be commented out after merging.
- The test case has been added to `arch_spatz_check` test, and automatically enabled in CI. 
## Notes

- This extension has been tested with buswidth `32` and `64` bit, and un-aligned starting addresses (e.g. `0x2002`).
- Modified instruction library implementations includes:
	- `vle8.v`, `vle16.v`, `vle32.v`, `vle64.v`
	-  `vse8.v`, `vse16.v`, `vse32.v`, `vse64.v`
- Other load and store instructions will be extended in the future work