### PR TITLE
Add FP8 Widening and AspB MatMul Kernels with Custom Instructions

### DIFF
--- a/examples/SoftHier/assembled/Spatz_GEMM/README.md
+++ b/examples/SoftHier/assembled/Spatz_GEMM/README.md
@@ -14,7 +14,14 @@ cfg={SOFTHIER_ROOT}/examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py 
 In this update, data generator script for compact N:M format has been added `write_index_to_header()`.
 - Currently only support 2:4 format for verification
 - Script utilization is the same
-- [ ] Add all N;M format to the generation script
+- [ ] Add all N:M format to the generation script
+Added AspB MatMul kernel utilizing `vfwxmul.vf` and `vfwxmacc.vf` instructions, passed functional verification.
+- [ ] Pending instruction timing verification.
+To analyze performance with UI, use the following command:
+```tcl
+cfg=examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py app=examples/SoftHier/assembled/Spatz_GEMM/software make hs; make runv pfto
+```
+Trace file will be generated at `sw_build/perfetto.json`. Use this trace file to analyze instruction timing.
 
 ### Software emulation of AspB MatMul (19.06.25)
 In this update, we assume matrix B is sparse with N:M format, and stored in a compact way along with the index matrix. Matrix A is still dense. The updated sw shows configuration and index translation overhead.

--- a/examples/SoftHier/assembled/Spatz_GEMM/README.md
+++ b/examples/SoftHier/assembled/Spatz_GEMM/README.md
@@ -20,12 +20,11 @@ python examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_sp_matmul_data
 # run simulation
 cfg=examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py app=examples/SoftHier/assembled/Spatz_GEMM/software make hs; make run
 ```
-[Attention!] 
+#### Attention!
 - We utilize `vsuxei8.v` instruction to handle index store operations. Therefore, the current implementation only support dimension `P` up to `256`. 
 - `fp16` accumulation is by default.
 - Index load and stroe is through VLSU. More efficiently is through VSLIDE unit. Could be extended baseline emulation.
 - [TODO] Merge data generation scripts.
-- [TODO] Add test for `vsuxeiX.v` instructions.
 
 
 ### Widening accumulation (18.06.25)

--- a/examples/SoftHier/assembled/Spatz_GEMM/README.md
+++ b/examples/SoftHier/assembled/Spatz_GEMM/README.md
@@ -8,5 +8,28 @@ Then build hardware and software with the provided configuration file:
 cfg={SOFTHIER_ROOT}/examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py app=examples/SoftHier/assembled/Spatz_GEMM/software make hs; make run
 ```
 
+## Updates
+
+### Software emulation of AspB MatMul (19.06.25)
+In this update, we assume matrix B is sparse with N:M format, and stored in a compact way along with the index matrix. Matrix A is still dense. The updated sw shows configuration and index translation overhead.
+
+To run the simulation:
+```tcl
+# data generation
+python examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_sp_matmul_datagen.py -M 16 -N 16 -P 16 -spN 2 -spM 4
+# run simulation
+cfg=examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py app=examples/SoftHier/assembled/Spatz_GEMM/software make hs; make run
+```
+[Attention!] 
+- We utilize `vsuxei8.v` instruction to handle index store operations. Therefore, the current implementation only support dimension `P` up to `256`. 
+- `fp16` accumulation is by default.
+- Index load and stroe is through VLSU. More efficiently is through VSLIDE unit. Could be extended baseline emulation.
+- [TODO] Merge data generation scripts.
+- [TODO] Add test for `vsuxeiX.v` instructions.
+
+
+### Widening accumulation (18.06.25)
+In this update, input element have `fp8` precision, and accumulate with `fp16` precision. 
+
 ## Note
 - Current implementation is based on fp8 (E5M2) format without widening accumulation. Rounding implementations in GVSoC and `datagen` script is different (GVSoC: per instruction, python: per kernel), which contributes to the mismatch in verification.

--- a/examples/SoftHier/assembled/Spatz_GEMM/README.md
+++ b/examples/SoftHier/assembled/Spatz_GEMM/README.md
@@ -10,6 +10,12 @@ cfg={SOFTHIER_ROOT}/examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py 
 
 ## Updates
 
+### Add compact index tensor generator (25.06.25)
+In this update, data generator script for compact N:M format has been added `write_index_to_header()`.
+- Currently only support 2:4 format for verification
+- Script utilization is the same
+- [ ] Add all N;M format to the generation script
+
 ### Software emulation of AspB MatMul (19.06.25)
 In this update, we assume matrix B is sparse with N:M format, and stored in a compact way along with the index matrix. Matrix A is still dense. The updated sw shows configuration and index translation overhead.
 

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
@@ -194,7 +194,7 @@ void spatz_AspB_matmul_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* ma
                 // load index 
                 uint8_t *p_index = &index_b[(p + n*P*spN/spM)/IDX_PER_BYTE];
                 asm volatile("vle8.v v8, (%0)" ::"r"(p_index));
-
+                // flex_timer_start();
                 if (n==0){ // first iter
                     // reset registers
                     asm volatile("vsetvli %0, %1, e16, m8, ta, ma" : "=r"(vl_dump) : "r"(2*avl));
@@ -221,8 +221,9 @@ void spatz_AspB_matmul_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* ma
                                 (0b10000   <<  7) | \
                                 (0b1010110 <<  0)   \n");
                 }
+                // flex_timer_end();
             }
-            asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
+            asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
             asm volatile("vse16.v v16, (%0)" ::"r"(p_c));
             asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(avl));
         }

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
@@ -16,8 +16,11 @@
 
 // Author: Bowen Wang, ETH Zurich
 
-// Dense MatMul: A x B = C, (MxN) x (NxP) --> (MxP)
-// Data Width:   8-bit
+// Spatz MatMul library: A x B = C, (MxN) x (NxP) --> (MxP)
+//
+//
+// spatz_matmul_fp8():  dense matmul [Gustav], input _fp8, output _fp8
+// spatz_matmul_fp16(): dense matmul [Gustav], input _fp8, output _fp16
 
 #ifndef _SPATZ_GEMM_H_
 #define _SPATZ_GEMM_H_
@@ -28,7 +31,7 @@
 
 #pragma GCC optimize("no-tree-loop-distribute-patterns")
 
-// outer product 
+// dense matmul [Gustav], input _fp8, output _fp8
 void spatz_matmul_fp8(uint8_t* matrix_a, uint8_t* matrix_b, uint8_t* matrix_c, 
                   const uint32_t M, const uint32_t N, const uint32_t P){
 
@@ -64,6 +67,7 @@ void spatz_matmul_fp8(uint8_t* matrix_a, uint8_t* matrix_b, uint8_t* matrix_c,
     } while (avl>0);
 }
 
+// dense matmul [Gustav], input _fp8, output _fp16
 void spatz_matmul_fp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, 
                   const uint32_t M, const uint32_t N, const uint32_t P){
 
@@ -97,7 +101,68 @@ void spatz_matmul_fp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c,
         avl -= vl;
         p += vl;
     } while (avl>0);
+}
 
+// sparse matmul [Gustav], AspB, input _fp8, index _uint8, output _fp16
+// effective output elements are gather/scatter with VLSU
+void spatz_AspB_matmul_fp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, uint8_t* index_b,
+                  const uint32_t M, const uint32_t N, const uint32_t P, 
+                  const uint8_t spN, const uint8_t spM){
+
+    // init counters
+    uint32_t p = 0;
+
+    uint32_t avl = P * spN / spM;
+    uint32_t vl;
+    uint32_t pre_vl = 0;
+    do{
+        asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(avl));
+        if (pre_vl != vl){    // vl changed, index re-calculate, otherwise skip
+            for (uint32_t i=0; i<N; i++){                        // row
+                for (uint32_t j=0; j<((P*spN/spM)/vl); j++){     // vl block
+                    for (uint32_t k=0; k<vl/spN; k++){           // nm block
+                        for (uint32_t q=0; q<spN; q++) index_b[q + k*spN + j*vl + i*(P*spN/spM)] += k*spM;
+                    }
+                }
+            }
+            pre_vl = vl;
+        }
+        
+        for (uint32_t m = 0; m < M; m++){
+            uint16_t *p_c = matrix_c + m*P + p;
+            for (uint32_t n = 0; n < N; n++){
+                // load a
+                uint8_t *p_a = &matrix_a[m*N + n];
+                asm volatile("flw fa0, (%0)" :: "r"(p_a));
+
+                // load b vec
+                uint8_t *p_b = &matrix_b[p + n*P*spN/spM];
+                asm volatile("vle8.v v0, (%0)" ::"r"(p_b));
+
+                // load index 
+                uint8_t *p_index = &index_b[p + n*P*spN/spM];
+                asm volatile("vle8.v v8, (%0)" ::"r"(p_index));
+
+                if (n==0){ // first iter
+                    asm volatile("vmv.v.i v16, 0");
+                    asm volatile("vfwmul.vf v16, v0, fa0");
+                    asm volatile("vsetvli %0, %1, e16, m8, ta, ma" : "=r"(vl) : "r"(avl));
+                    asm volatile("vsuxei8.v v16, (%0), v8" ::"r"(p_c));
+                    asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(avl));
+                } else {
+                    asm volatile("vsetvli %0, %1, e16, m8, ta, ma" : "=r"(vl) : "r"(avl));
+                    asm volatile("vluxei8.v v16, (%0), v8" ::"r"(p_c));
+                    asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(avl));
+                    asm volatile("vfwmacc.vf v16, fa0, v0");
+                    asm volatile("vsetvli %0, %1, e16, m8, ta, ma" : "=r"(vl) : "r"(avl));
+                    asm volatile("vsuxei8.v v16, (%0), v8" ::"r"(p_c));
+                    asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(avl));
+                }
+            }
+        }
+        avl -= vl;
+        p += vl;
+    } while (avl>0);
 }
 
 #endif

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
@@ -29,7 +29,7 @@
 #pragma GCC optimize("no-tree-loop-distribute-patterns")
 
 // outer product 
-void spatz_matmul(uint8_t* matrix_a, uint8_t* matrix_b, uint8_t* matrix_c, 
+void spatz_matmul_fp8(uint8_t* matrix_a, uint8_t* matrix_b, uint8_t* matrix_c, 
                   const uint32_t M, const uint32_t N, const uint32_t P){
 
     // init counters
@@ -58,6 +58,41 @@ void spatz_matmul(uint8_t* matrix_a, uint8_t* matrix_b, uint8_t* matrix_c,
                 }
             }
             asm volatile("vse8.v v16, (%0)" ::"r"(p_c));
+        }
+        avl -= vl;
+        p += vl;
+    } while (avl>0);
+}
+
+void spatz_matmul_fp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, 
+                  const uint32_t M, const uint32_t N, const uint32_t P){
+
+    // init counters
+    uint32_t p = 0;
+
+    uint32_t avl = P;
+    uint32_t vl;
+    do{
+        asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(avl));
+        for (uint32_t m = 0; m < M; m++){
+            uint16_t *p_c = matrix_c + m*P + p;
+            for (uint32_t n = 0; n < N; n++){
+                // load a
+                uint8_t *p_a = &matrix_a[m*N + n];
+                asm volatile("flw fa0, (%0)" :: "r"(p_a));
+
+                // load b vec
+                uint8_t *p_b = &matrix_b[p + n*P];
+
+                asm volatile("vle8.v v0, (%0)" ::"r"(p_b));
+                if (n==0){ // first iter
+                    asm volatile("vmv.v.i v16, 0");
+                    asm volatile("vfwmul.vf v16, v0, fa0");
+                } else {
+                    asm volatile("vfwmacc.vf v16, fa0, v0");
+                }
+            }
+            asm volatile("vse16.v v16, (%0)" ::"r"(p_c));
         }
         avl -= vl;
         p += vl;

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
@@ -17,7 +17,7 @@
 #include "flex_runtime.h"
 
 #include "spatz_matmul.h"
-#include "data_spatz_matmul_fp8.h"
+#include "data_spatz_sp_matmul_fp8.h"
 #include <math.h>
 
 // input output type define
@@ -49,35 +49,57 @@ int main()
     uint32_t core_id = flex_get_core_id();
 
     if (core_id == 0 && CID == 0){
-        // allocation
+        // Step1: allocation
         uint8_t *matrix_a = (uint8_t *)flex_l1_malloc(FP8_M * FP8_N * sizeof(uint8_t));
+        #ifndef __SPARSE__
         uint8_t *matrix_b = (uint8_t *)flex_l1_malloc(FP8_N * FP8_P * sizeof(uint8_t));
+        #else
+        uint8_t *matrix_b = (uint8_t *)flex_l1_malloc(FP8_N * FP8_P * spN/spM * sizeof(uint8_t));
+        uint8_t *index_b  = (uint8_t *)flex_l1_malloc(FP8_N * FP8_P * spN/spM * sizeof(uint8_t));
+        #endif //__SPARSE__ allocation
+
         #if _OUT_TYPE == 1
         uint8_t *matrix_c = (uint8_t *)flex_l1_malloc(FP8_M * FP8_P * sizeof(uint8_t));
         #elif _OUT_TYPE == 2
         uint16_t *matrix_c = (uint16_t *)flex_l1_malloc(FP8_M * FP8_P * sizeof(uint16_t));
         #else
             #error "Unsupported _OUT_TYPE value"
-        #endif
+        #endif // _OUT_TYPE
 
-        // data movement
+        // Step 2: data movement
         for (uint32_t i=0; i<FP8_M * FP8_N; i++){
             matrix_a[i] = matrix_a_fp8[i];
         }
+        #ifndef __SPARSE__
         for (uint32_t i=0; i<FP8_N * FP8_P; i++){
             matrix_b[i] = matrix_b_fp8[i];
         }
+        #else
+        for (uint32_t i=0; i<FP8_N * FP8_P * spN/spM; i++){
+            matrix_b[i] = matrix_b_compact_fp8[i];
+            index_b[i] = matrix_b_index_uint8[i];
+        }
+        for (uint32_t i=0; i<FP8_M * FP8_P; i++){
+            matrix_c[i] = 0; // init matrix c
+        }
+        #endif // __SPARSE__ data movement
+
+        // Step 3: Compute
         #if _OUT_TYPE == 1
         spatz_matmul_fp8(matrix_a, matrix_b, matrix_c, FP8_M, FP8_N, FP8_P);
         // verify
         spatz_verify(FP8_M * FP8_P, matrix_c, matrix_c_fp8, 0.25f);
         #elif _OUT_TYPE == 2
+
+        #ifndef __SPARSE__
         spatz_matmul_fp16(matrix_a, matrix_b, matrix_c, FP8_M, FP8_N, FP8_P);
+        #else
+        spatz_AspB_matmul_fp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
+        #endif // __SPARSE__ compute
+
         // verify
         spatz_verify_16(FP8_M * FP8_P, matrix_c, matrix_c_fp16, 0.25f);
-        #endif
-
-        
+        #endif // _OUT_TYPT compute
     }
 
     /**************************************/

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
@@ -103,6 +103,7 @@ int main()
         #endif // __SPARSE__ data movement
 
         // Step 3: Compute
+        flex_timer_start();
         #if _OUT_TYPE == 1
         spatz_matmul_fp8(matrix_a, matrix_b, matrix_c, FP8_M, FP8_N, FP8_P);
         // verify
@@ -119,6 +120,7 @@ int main()
         spatz_AspB_matmul_fp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
         #endif
         #endif // __SPARSE__ compute
+        flex_timer_end();
 
         // verify
         spatz_verify_16(FP8_M * FP8_P, matrix_c, matrix_c_fp16, 0.25f);

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_matmul_datagen.py
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_matmul_datagen.py
@@ -15,74 +15,17 @@
 import os
 import numpy as np
 import argparse
-
-def float_to_fp8_e4m3(val):
-    """Encode float16 value into simulated fp8 (E4M3) format (bias=7, 4 exponent bits, 3 mantissa bits)."""
-    f16 = np.float16(val)
-    b = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
-
-    sign = (b >> 15) & 0x1
-    exp  = (b >> 10) & 0x1F  # 5-bit exponent
-    frac = (b >> 7)  & 0x7   # top 3 mantissa bits
-
-    if exp == 0 and frac == 0:
-        return 0x00
-    elif exp == 0x1F:
-        return 0x7F if sign == 0 else 0xFF  # Inf or NaN
-
-    fp8_exp = exp - 15 + 7  # Bias shift: float16 bias=15, E4M3 bias=7
-    if fp8_exp <= 0:
-        return 0x00  # Underflow to zero
-    elif fp8_exp >= 0xF:
-        return 0x7F if sign == 0 else 0xFF  # Overflow to max
-
-    result = (sign << 7) | ((fp8_exp & 0xF) << 3) | (frac & 0x7)
-    return result
-
-def float_to_fp8_e5m2(val):
-    """Encode float16 value into simulated fp8 (E5M2) format (bias=15, 5 exponent bits, 2 mantissa bits)."""
-    f16 = np.float16(val)
-    b = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
-
-    sign = (b >> 15) & 0x1
-    exp  = (b >> 10) & 0x1F  # 5-bit exponent
-    frac = (b >> 8)  & 0x3   # top 2 mantissa bits
-
-    if exp == 0 and frac == 0:
-        return 0x00
-    elif exp == 0x1F:
-        return 0x7F if sign == 0 else 0xFF  # Inf or NaN
-
-    result = (sign << 7) | ((exp & 0x1F) << 2) | (frac & 0x3)
-    return result
-
-def generate_fp8_matrix(rows, cols):
-    """Generate a matrix with values in the range [-1, 1], stored in float16."""
-    return np.random.uniform(-1.0, 1.0, size=(rows, cols)).astype(np.float16)
-
-def write_matrix_to_header(f, name, mat, fmt='e4m3', dtype='uint8_t'):
-    """Write a flattened matrix to C header as uint8_t fp8-encoded values."""
-    flat = mat.flatten()
-    f.write(f'static const {dtype} {name}[{len(flat)}] = {{\n')
-    for i, val in enumerate(flat):
-        if fmt == 'e4m3':
-            int_val = float_to_fp8_e4m3(val)
-        elif fmt == 'e5m2':
-            int_val = float_to_fp8_e5m2(val)
-        else:
-            raise ValueError(f"Unsupported format: {fmt}")
-        f.write(f'  0x{int_val:02X},')
-        if (i + 1) % 8 == 0:
-            f.write('\n')
-    f.write('};\n\n')
+from flex_libfp8 import generate_fp8_matrix, write_matrix_to_header
 
 def main():
     parser = argparse.ArgumentParser(description='FP8 Matrix Generator')
     parser.add_argument('-M', type=int, required=True, help='Number of rows in matrix A and C')
     parser.add_argument('-N', type=int, required=True, help='Number of cols in A, rows in B')
     parser.add_argument('-P', type=int, required=True, help='Number of columns in matrix B and C')
-    parser.add_argument('--format', choices=['e4m3', 'e5m2'], default='e4m3',
-                        help='FP8 format to use: e4m3 or e5m2 (default: e4m3)')
+    parser.add_argument('--input_format', choices=['e4m3', 'e5m2'], default='e5m2',
+                        help='FP8 format to use: e4m3 or e5m2 (default: e5m2)')
+    parser.add_argument('--output_format', choices=['e4m3', 'e5m2', 'fp16'], default='fp16',
+                        help='Output format to use: fp8 [e4m3 or e5m2] | fp16 (default: fp16)')
     args = parser.parse_args()
 
     M, N, P = args.M, args.N, args.P
@@ -108,9 +51,12 @@ def main():
         f.write(f'#define FP8_N {N}\n')
         f.write(f'#define FP8_P {P}\n\n')
 
-        write_matrix_to_header(f, 'matrix_a_fp8', A, fmt=args.format)
-        write_matrix_to_header(f, 'matrix_b_fp8', B, fmt=args.format)
-        write_matrix_to_header(f, 'matrix_c_fp8', C, fmt=args.format)
+        write_matrix_to_header(f, 'matrix_a_fp8', A, fmt=args.input_format)
+        write_matrix_to_header(f, 'matrix_b_fp8', B, fmt=args.input_format)
+        if args.output_format == 'fp16':
+            write_matrix_to_header(f, 'matrix_c_fp16', C, fmt='fp16', dtype='uint16_t')
+        else:
+            write_matrix_to_header(f, 'matrix_c_fp8', C, fmt=args.output_format, dtype='uint8_t')
 
         f.write('#endif // SPATZ_MATMUL_FP8_H\n')
 

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_sp_matmul_datagen.py
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_sp_matmul_datagen.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2025 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Author: Bowen Wang, ETH Zurich
+# This script generates fp8_sp_matmul input/output header file
+# Input dense matrix A (fp_8), input sparse matrix B (fp_8)
+# Output dense matrix C (fp_16)
+
+import os
+import numpy as np
+import argparse
+from flex_libfp8 import write_matrix_to_header, generate_sparse_fp8_matrix, generate_fp8_matrix, extract_nm_sparsity
+
+def main():
+    parser = argparse.ArgumentParser(description='FP8 Matrix Generator')
+    # matrix dimension
+    parser.add_argument('-M', type=int, required=True, default=16, help='Number of rows in matrix A and C')
+    parser.add_argument('-N', type=int, required=True, default=16, help='Number of cols in A, rows in B')
+    parser.add_argument('-P', type=int, required=True, default=16, help='Number of columns in matrix B and C')
+    # sparsity format: N:M
+    parser.add_argument('-spN', type=int, required=True, default=2, help='[N]:M format')
+    parser.add_argument('-spM', type=int, required=True, default=4, help='N:[M] format')
+    # data format
+    parser.add_argument('--input_format', choices=['e4m3', 'e5m2'], default='e5m2',
+                        help='FP8 format to use: e4m3 or e5m2 (default: e5m2)')
+    parser.add_argument('--output_format', choices=['e4m3', 'e5m2', 'fp16'], default='fp16',
+                        help='Output format to use: fp8 [e4m3 or e5m2] | fp16 (default: fp16)')
+    args = parser.parse_args()
+
+    M, N, P = args.M, args.N, args.P
+    spM, spN = args.spM, args.spN
+
+    # Generate float16 input matrices (fp16 represented fp8 precision)
+    A = generate_fp8_matrix(M, N)
+    B = generate_sparse_fp8_matrix(N, P, spN, spM)
+    # Compact matrix and index
+    B_compact, B_index = extract_nm_sparsity(B, spN, spM)
+
+    # Compute matrix multiplication in float16
+    C = np.matmul(A.astype(np.float16), B.astype(np.float16))
+
+    # Compute output path
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    include_dir = os.path.abspath(os.path.join(script_dir, '..', 'include'))
+    os.makedirs(include_dir, exist_ok=True)
+    header_path = os.path.join(include_dir, 'data_spatz_sp_matmul_fp8.h')
+
+    with open(header_path, 'w') as f:
+        f.write('#ifndef SPATZ_SPARSE_MATMUL_FP8_H\n')
+        f.write('#define SPATZ_SPARSE_MATMUL_FP8_H\n\n')
+
+        f.write(f'#define FP8_M {M}\n')
+        f.write(f'#define FP8_N {N}\n')
+        f.write(f'#define FP8_P {P}\n\n')
+        
+        f.write(f'#define __SPARSE__\n')
+        f.write(f'#define spN {spN}\n')
+        f.write(f'#define spM {spM}\n\n')
+
+        write_matrix_to_header(f, 'matrix_a_fp8', A, fmt=args.input_format)
+        write_matrix_to_header(f, 'matrix_b_fp8', B, fmt=args.input_format)
+        write_matrix_to_header(f, 'matrix_b_compact_fp8', B_compact, fmt=args.input_format)
+        write_matrix_to_header(f, 'matrix_b_index_uint8', B_index, fmt='uint8', dtype='uint8_t')
+        if args.output_format == 'fp16':
+            write_matrix_to_header(f, 'matrix_c_fp16', C, fmt='fp16', dtype='uint16_t')
+        else:
+            write_matrix_to_header(f, 'matrix_c_fp8', C, fmt=args.output_format, dtype='uint8_t')
+
+        f.write('#endif // SPATZ_SPARSE_MATMUL_FP8_H\n')
+
+    print(f'[✓] Header written to: {header_path}')
+
+if __name__ == '__main__':
+    main()

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_sp_matmul_datagen.py
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_sp_matmul_datagen.py
@@ -17,7 +17,7 @@
 import os
 import numpy as np
 import argparse
-from flex_libfp8 import write_matrix_to_header, generate_sparse_fp8_matrix, generate_fp8_matrix, extract_nm_sparsity
+from flex_libfp8 import write_matrix_to_header, write_index_to_header, generate_sparse_fp8_matrix, generate_fp8_matrix, extract_nm_sparsity
 
 def main():
     parser = argparse.ArgumentParser(description='FP8 Matrix Generator')
@@ -69,6 +69,7 @@ def main():
         write_matrix_to_header(f, 'matrix_b_fp8', B, fmt=args.input_format)
         write_matrix_to_header(f, 'matrix_b_compact_fp8', B_compact, fmt=args.input_format)
         write_matrix_to_header(f, 'matrix_b_index_uint8', B_index, fmt='uint8', dtype='uint8_t')
+        write_index_to_header(f, 'matrix_b_index_compact_uint8', B_index, fmt='nm2bit', dtype='uint8_t')
         if args.output_format == 'fp16':
             write_matrix_to_header(f, 'matrix_c_fp16', C, fmt='fp16', dtype='uint16_t')
         else:

--- a/examples/SoftHier/software/spatz_check/README.md
+++ b/examples/SoftHier/software/spatz_check/README.md
@@ -1,0 +1,10 @@
+# Gather-Mul-Scatter instructions
+`vfwxmul.vf` and `vfwxmacc.vf` custom RVV instructions has been added to Spatz model. This folder contains basic functional verification for these instructions. 
+
+Use the following command to test:
+```
+cfg=examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py app=examples/SoftHier/software/spatz_check make hs; make run
+```
+
+## Note
+- The current test vectors are generated manually, and constrained with `_AVL=16`. --> [TODO] Add the compact test vector generation into `fp16_util`.

--- a/examples/SoftHier/software/spatz_check/include/spatz_custom_isa.h
+++ b/examples/SoftHier/software/spatz_check/include/spatz_custom_isa.h
@@ -1,0 +1,152 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: Bowen Wang, ETH Zurich
+
+// Customized RVV instruction (vfwxmul.vf, vfwxmacc.vf) check
+
+#ifndef _SPATZ_ISA_CHECK_H_
+#define _SPATZ_ISA_CHECK_H_
+
+#include "flex_runtime.h"
+#include "flex_printf.h"
+// #include "flex_libfp8.h"
+
+#define _AVL (16)
+
+#pragma GCC optimize("no-tree-loop-distribute-patterns")
+
+void test_spatz_isa(){
+    flex_global_barrier_xy();//Global barrier
+    flex_alloc_init();
+    flex_intra_cluster_sync();
+    flex_global_barrier_xy();
+
+    uint32_t CID = flex_get_cluster_id(); // Get cluster ID
+    uint32_t core_id = flex_get_core_id();
+
+    if (CID == 0 && core_id == 0)
+    {
+
+        uint32_t avl, vl, vl_dump;
+        uint8_t err = 0;
+        avl = _AVL;
+
+        // odd indeices
+        __attribute__((section(".hbm"))) static const uint8_t index[_AVL/4] = 
+                        {0b11011101, 0b11011101, 0b11011101, 0b11011101};
+        // even indices
+        __attribute__((section(".hbm"))) static const uint8_t index_macc[_AVL/4] = 
+                        {0b10001000, 0b10001000, 0b10001000, 0b10001000};
+        // input vector
+        __attribute__((section(".hbm"))) static const uint8_t inp_vec[_AVL] = 
+                        { 0x36,  0x37,  0xB5,  0x3A,  0x39,  0xAD,  0xB7,  0xB8,
+                        0x3B,  0x36,  0xAE,  0xAB,  0x29,  0x29,  0x39,  0x3A,};
+        // expected vector
+        __attribute__((section(".hbm"))) static const uint16_t exp_vec[_AVL] = 
+                    {   0xAF80,  0xB060,  0x2E40,  0xB380,  0xB240,  0x2640,  0x3060,  0x3100,
+                        0xB460,  0xAF80,  0x2780,  0x2460,  0xA240,  0xA240,  0xB240,  0xB380,};
+
+        uint8_t * ref_ind = (void *)local(0x2000);
+        uint8_t * ref_inp = (void *)local(0x4000);
+        uint16_t * oup_vec = (void *)local(0x10000);
+
+        for (int i=0; i<_AVL/4; i++){
+            ref_ind[i] = index[i];
+        }
+        for (int i=0; i<_AVL; i++){
+            ref_inp[i] = inp_vec[i];
+            oup_vec[i] = 0;
+            oup_vec[_AVL+i] = 0;
+        }
+        uint8_t s_fp8[1] =  {0xB5,};
+
+        // vfwxmul.vf
+        printf("[ins] vfwxmul.vf \n");
+        do{
+            asm volatile("vsetvli %0, %1, e16, m4, ta, ma" : "=r"(vl_dump) : "r"(2*avl));
+            asm volatile("vmv.v.i v8, 0");
+            asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
+            asm volatile("flw ft0, (%0)" :: "r"(s_fp8));
+            asm volatile("vle8.v v0, (%0)" ::"r"(ref_ind));
+            asm volatile("vle8.v v4, (%0)" ::"r"(ref_inp));
+            asm volatile(
+                 ".word (0b110011  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00100   << 20) | \
+                        (0b00000   << 15) | \
+                        (0b000     << 12) | \
+                        (0b01000   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+            asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
+            asm volatile("vse16.v v8, (%0)" ::"r"(oup_vec));
+            avl -= vl;
+        } while (avl>0);
+        
+        for (int i=0; i<_AVL; i++){
+            uint16_t res_odd = oup_vec[2*i + 1];
+            uint16_t exp     = exp_vec[i];
+            if (res_odd != exp) {
+                printf("MISMATCH: exp 0x%x, got 0x%x\n", exp, res_odd);
+                err += 1;
+            }
+        }
+
+        for (int i=0; i<_AVL/4; i++){
+            ref_ind[i] = index_macc[i];
+        }
+
+        // vfwxmacc.vv
+        printf("[ins] vfwxmacc.vf \n");
+        avl = _AVL;
+        do{
+            asm volatile("vsetvli %0, %1, e16, m4, ta, ma" : "=r"(vl_dump) : "r"(2*avl));
+            asm volatile("vle16.v v8, (%0)" ::"r"(oup_vec));
+            asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
+            asm volatile("flw ft0, (%0)" :: "r"(s_fp8));
+            asm volatile("vle8.v v0, (%0)" ::"r"(ref_ind));
+            asm volatile("vle8.v v4, (%0)" ::"r"(ref_inp));
+            asm volatile(
+                 ".word (0b110001  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00100   << 20) | \
+                        (0b00000   << 15) | \
+                        (0b000     << 12) | \
+                        (0b01000   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+            asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
+            asm volatile("vse16.v v8, (%0)" ::"r"(oup_vec));
+            avl -= vl;
+        } while (avl>0);
+        
+        for (int i=0; i<_AVL; i++){
+            uint16_t res_odd  = oup_vec[2*i + 1];
+            uint16_t res_even = oup_vec[2*i];
+            uint16_t exp     = exp_vec[i];
+            if (res_odd != exp || res_even != exp) {
+                printf("MISMATCH: exp 0x%x, got even 0x%x, got odd 0x%x\n", exp, res_even, res_odd);
+                err += 1;
+            }
+        }
+
+        printf(">>> Total %d error(s) found.\n", err);
+
+    }
+
+    flex_global_barrier_xy();//Global barrier
+}
+
+#endif

--- a/examples/SoftHier/software/spatz_check/include/spatz_fp8_check.h
+++ b/examples/SoftHier/software/spatz_check/include/spatz_fp8_check.h
@@ -25,7 +25,7 @@
 #include "flex_printf.h"
 #include "flex_libfp8.h"
 
-#include "spatz_fp8_check_data.h"
+#include "data_spatz_fp8_check.h"
 
 #pragma GCC optimize("no-tree-loop-distribute-patterns")
 
@@ -51,9 +51,8 @@ void test_spatz_fp8(){
             vector_c[i] = vector_c_fp8[i];
         }
 
-        // float scalar_s  = (float)s_fp8[0]; // put this element in fp register
-        float scalar_s;
-        set_lower_byte(&scalar_s, s_fp8[0]);
+        // load scalar
+        asm volatile("flw fa0, (%0)" :: "r"(s_fp8));
 
         uint32_t avl, vl, p;
         uint8_t *p_a, *p_b, *p_c, *p_res;
@@ -73,7 +72,7 @@ void test_spatz_fp8(){
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_add_vv_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_add_vv_fp8, 0.25f);
 
         // vfsub.vv
         printf("[ins] vfsub.vv \n");
@@ -91,7 +90,7 @@ void test_spatz_fp8(){
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_sub_vv_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_sub_vv_fp8, 0.25f);
 
         // vfmin.vv
         printf("[ins] vfmin.vv \n");
@@ -109,7 +108,7 @@ void test_spatz_fp8(){
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_min_vv_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_min_vv_fp8, 0.25f);
 
         // vfmax.vv
         printf("[ins] vfmax.vv \n");
@@ -127,7 +126,7 @@ void test_spatz_fp8(){
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_max_vv_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_max_vv_fp8, 0.25f);
 
         // vfmul.vv
         printf("[ins] vfmul.vv \n");
@@ -145,7 +144,7 @@ void test_spatz_fp8(){
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_mul_vv_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_mul_vv_fp8, 0.25f);
 
         // vfmadd.vv
         printf("[ins] vfmadd.vv \n");
@@ -165,7 +164,7 @@ void test_spatz_fp8(){
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_madd_vv_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_madd_vv_fp8, 0.25f);
 
         // vfmacc.vv
         printf("[ins] vfmacc.vv \n");
@@ -185,7 +184,7 @@ void test_spatz_fp8(){
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_macc_vv_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_macc_vv_fp8, 0.25f);
 
         // vfadd.vf
         printf("[ins] vfadd.vf \n");
@@ -196,12 +195,12 @@ void test_spatz_fp8(){
             p_res = vector_res + p;
             asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
             asm volatile("vle8.v v0, (%0)" ::"r"(p_a));
-            asm volatile("vfadd.vf v8, v0, %0" ::"f"(scalar_s)); // res = a + broadcast(s);
+            asm volatile("vfadd.vf v8, v0, fa0"); // res = a + broadcast(s);
             asm volatile("vse8.v v8, (%0)" ::"r"(p_res));
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_add_vf_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_add_vf_fp8, 0.25f);
 
         // vfsub.vf
         printf("[ins] vfsub.vf \n");
@@ -212,12 +211,12 @@ void test_spatz_fp8(){
             p_res = vector_res + p;
             asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
             asm volatile("vle8.v v0, (%0)" ::"r"(p_a));
-            asm volatile("vfsub.vf v8, v0, %0" ::"f"(scalar_s)); // res = a - broadcast(s);
+            asm volatile("vfsub.vf v8, v0, fa0"); // res = a - broadcast(s);
             asm volatile("vse8.v v8, (%0)" ::"r"(p_res));
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_sub_vf_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_sub_vf_fp8, 0.25f);
 
         // vfmul.vf
         printf("[ins] vfmul.vf \n");
@@ -228,12 +227,12 @@ void test_spatz_fp8(){
             p_res = vector_res + p;
             asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
             asm volatile("vle8.v v0, (%0)" ::"r"(p_a));
-            asm volatile("vfmul.vf v8, v0, %0" ::"f"(scalar_s)); // res = a - broadcast(s);
+            asm volatile("vfmul.vf v8, v0, fa0"); // res = a - broadcast(s);
             asm volatile("vse8.v v8, (%0)" ::"r"(p_res));
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_mul_vf_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_mul_vf_fp8, 0.25f);
 
         // vfmadd.vf
         printf("[ins] vfmadd.vf \n"); // C = C x s + A
@@ -245,12 +244,12 @@ void test_spatz_fp8(){
             asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
             asm volatile("vle8.v v0, (%0)" ::"r"(p_a));
             asm volatile("vle8.v v8, (%0)" ::"r"(p_c));
-            asm volatile("vfmadd.vf v8, %0, v0" ::"f"(scalar_s));
+            asm volatile("vfmadd.vf v8, fa0, v0");
             asm volatile("vse8.v v8, (%0)" ::"r"(p_res));
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_madd_vf_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_madd_vf_fp8, 0.25f);
 
         // vfmacc.vf
         printf("[ins] vfmacc.vf \n"); // C = A x s + C
@@ -262,12 +261,12 @@ void test_spatz_fp8(){
             asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
             asm volatile("vle8.v v0, (%0)" ::"r"(p_a));
             asm volatile("vle8.v v8, (%0)" ::"r"(p_c));
-            asm volatile("vfmacc.vf v8, %0, v0" ::"f"(scalar_s));
+            asm volatile("vfmacc.vf v8, fa0, v0");
             asm volatile("vse8.v v8, (%0)" ::"r"(p_res));
             avl -= vl;
             p += vl;
         } while (avl>0);
-        spatz_verify(_AVL, vector_res, vector_c_macc_vf_fp8);
+        spatz_verify(_AVL, vector_res, vector_c_macc_vf_fp8, 0.25f);
     }
 
     flex_global_barrier_xy();//Global barrier

--- a/examples/SoftHier/software/spatz_check/include/spatz_indexed_check.h
+++ b/examples/SoftHier/software/spatz_check/include/spatz_indexed_check.h
@@ -1,3 +1,23 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: Bowen Wang, ETH Zurich
+
+// RVV indexed load and store instruction tests
+
 #ifndef _INDEXED_H_
 #define _INDEXED_H_
 
@@ -5,35 +25,19 @@
 #include "flex_printf.h"
 #include "flex_libfp16.h"
 
-#define _AVL (64)
+#define _AVL (128)
+#define PRECISION_8BIT  (8)
+#define PRECISION_16BIT (16)
+#define PRECISION_32BIT (32)
+#define PRECISION_64BIT (64)
+
 #pragma GCC optimize("no-tree-loop-distribute-patterns")
 
-void l1_layout(uint8_t *addr, uint8_t size){ // size in byte
-    // align the output
-    uint8_t offset = ((uint32_t)addr) % (8*8);
-    uint8_t * addr_aligned = (uint8_t *)((uint32_t)addr - offset);
-    // dump info 8 x 8bytes
-    int8_t size_aligned = size + offset;
-
-    do{
-        printf("0x%8x - 0x%8x >  ", addr_aligned, addr_aligned+8*8-1);
-        for (int j=0; j<4; j++){
-            for (int k=0; k<8; k++){
-                if (k<7) printf("%2x_", addr_aligned[j+k]);
-                else     printf("%2x", addr_aligned[j+k]);
-            }
-            printf("  |  ");
-        }
-        printf("\n");
-        addr_aligned += 4*8;
-        size_aligned -= 4*8;
-    } while (size_aligned>0);
-}
-
+// Indexed load
 uint8_t test_ele8_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Load Tests: 8-bit ele, 8-bit index]\n");
+    printf("[Index Load Tests: 8-bit ele, 8-bit index] ");
     uint8_t * inp_8 = (uint8_t *)ref_inp;
     uint8_t * ind_8 = (uint8_t *)ref_ind;
     uint8_t * oup_8 = (uint8_t *)ref_oup;
@@ -41,10 +45,8 @@ uint8_t test_ele8_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL*8; ++i) inp_8[i] = i+1;
-    printf("[Init inp_8, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind_8[i] = 3*i+1;
-    printf("[Init ind_8, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp_8[i] = 2 * inp_8[ind_8[i]];
@@ -61,7 +63,6 @@ uint8_t test_ele8_index8(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < _AVL; ++i){
         if (exp_8[i] != oup_8[i]) err+=1;
@@ -82,7 +83,7 @@ uint8_t test_ele8_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 uint8_t test_ele8_index16(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Load Tests: 8-bit ele, 16-bit index]\n");
+    printf("[Index Load Tests: 8-bit ele, 16-bit index] ");
     uint8_t  * inp = (uint8_t *)ref_inp;
     uint16_t * ind = (uint16_t *)ref_ind;
     uint8_t  * oup = (uint8_t *)ref_oup;
@@ -90,10 +91,8 @@ uint8_t test_ele8_index16(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL*8; ++i) inp[i] = i+1;
-    printf("[Init inp, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
-    printf("[Init ind, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp[i] = 2 * inp[ind[i]];
@@ -110,7 +109,6 @@ uint8_t test_ele8_index16(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < _AVL; ++i){
         if (exp[i] != oup[i]) err+=1;
@@ -132,7 +130,7 @@ uint8_t test_ele8_index16(void * ref_inp, void * ref_ind, void * ref_oup){
 uint8_t test_ele8_index32(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Load Tests: 8-bit ele, 32-bit index]\n");
+    printf("[Index Load Tests: 8-bit ele, 32-bit index] ");
     uint8_t  * inp = (uint8_t *)ref_inp;
     uint32_t * ind = (uint32_t *)ref_ind;
     uint8_t  * oup = (uint8_t *)ref_oup;
@@ -140,10 +138,8 @@ uint8_t test_ele8_index32(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL*8; ++i) inp[i] = i+1;
-    printf("[Init inp, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
-    printf("[Init ind, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp[i] = 2 * inp[ind[i]];
@@ -160,7 +156,6 @@ uint8_t test_ele8_index32(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < _AVL; ++i){
         if (exp[i] != oup[i]) err+=1;
@@ -182,7 +177,7 @@ uint8_t test_ele8_index32(void * ref_inp, void * ref_ind, void * ref_oup){
 uint8_t test_ele8_index64(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Load Tests: 8-bit ele, 64-bit index]\n");
+    printf("[Index Load Tests: 8-bit ele, 64-bit index] ");
     uint8_t  * inp = (uint8_t *)ref_inp;
     uint64_t * ind = (uint64_t *)ref_ind;
     uint8_t  * oup = (uint8_t *)ref_oup;
@@ -190,10 +185,8 @@ uint8_t test_ele8_index64(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL*8; ++i) inp[i] = i+1;
-    printf("[Init inp, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
-    printf("[Init ind, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp[i] = 2 * inp[ind[i]];
@@ -210,7 +203,6 @@ uint8_t test_ele8_index64(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < _AVL; ++i){
         if (exp[i] != oup[i]) err+=1;
@@ -232,7 +224,7 @@ uint8_t test_ele8_index64(void * ref_inp, void * ref_ind, void * ref_oup){
 uint8_t test_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Load Tests: 16-bit ele, 8-bit index]\n");
+    printf("[Index Load Tests: 16-bit ele, 8-bit index] ");
     uint16_t  * inp = (uint16_t *)ref_inp;
     uint8_t   * ind = (uint8_t *)ref_ind;
     uint16_t  * oup = (uint16_t *)ref_oup;
@@ -240,10 +232,8 @@ uint8_t test_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL*8; ++i) inp[i] = i+1;
-    printf("[Init inp, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
-    printf("[Init ind, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp[i] = 2 * inp[ind[i]];
@@ -260,7 +250,6 @@ uint8_t test_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < _AVL; ++i){
         if (exp[i] != oup[i]){
@@ -285,7 +274,7 @@ uint8_t test_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 uint8_t test_ele32_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Load Tests: 32-bit ele, 8-bit index]\n");
+    printf("[Index Load Tests: 32-bit ele, 8-bit index] ");
     uint32_t  * inp = (uint32_t *)ref_inp;
     uint8_t   * ind = (uint8_t *)ref_ind;
     uint32_t  * oup = (uint32_t *)ref_oup;
@@ -293,10 +282,8 @@ uint8_t test_ele32_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL*8; ++i) inp[i] = i+1;
-    printf("[Init inp, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
-    printf("[Init ind, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp[i] = 2 * inp[ind[i]];
@@ -313,7 +300,6 @@ uint8_t test_ele32_index8(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < _AVL; ++i){
         if (exp[i] != oup[i]){
@@ -338,7 +324,7 @@ uint8_t test_ele32_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 uint8_t test_ele64_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Load Tests: 64-bit ele, 8-bit index]\n");
+    printf("[Index Load Tests: 64-bit ele, 8-bit index] ");
     uint64_t  * inp = (uint64_t *)ref_inp;
     uint8_t   * ind = (uint8_t *)ref_ind;
     uint64_t  * oup = (uint64_t *)ref_oup;
@@ -346,10 +332,8 @@ uint8_t test_ele64_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL*8; ++i) inp[i] = i+1;
-    printf("[Init inp, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
-    printf("[Init ind, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp[i] = 2 * inp[ind[i]];
@@ -366,7 +350,6 @@ uint8_t test_ele64_index8(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < _AVL; ++i){
         if (exp[i] != oup[i]){
@@ -388,11 +371,65 @@ uint8_t test_ele64_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     return err;
 }
 
-// index store
+// Indexed store
+uint8_t test_st_ele8_index8(void * ref_inp, void * ref_ind, void * ref_oup){
+    uint32_t vl;
+    uint32_t avl;
+    printf("[Index Store Tests: 8-bit ele, 8-bit index] ");
+    uint8_t  * inp = (uint8_t *)ref_inp;
+    uint8_t  * ind = (uint8_t *)ref_ind;
+    uint8_t  * oup = (uint8_t *)ref_oup;
+    uint8_t  * exp = (uint8_t *)local(0x8000);
+
+    // init vector
+    for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
+    // init output
+    for (int i = 0; i < 8 * _AVL; ++i) {
+        oup[i] = 0;
+        exp[i] = 0;
+    }
+    // init index
+    for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
+    // calculate expected output
+    for (int i = 0; i < _AVL; ++i){
+        exp[ind[i]] = inp[i];
+    }
+
+    // index load
+    avl = _AVL;
+    do{
+        asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        asm volatile("vle8.v v0, (%0)" ::"r"(ind));
+        asm volatile("vle8.v v2, (%0)" ::"r"(inp));
+        asm volatile("vsuxei8.v v2, (%0), v0" ::"r"(oup));
+        avl -= vl;
+    } while (avl>0);
+
+    uint8_t err = 0;
+    for (int i = 0; i < 8*_AVL; ++i){
+        if (exp[i] != oup[i]){
+            err+=1;
+            printf("exp: %d, oup: %d\n", exp[i], oup[i]);
+        } 
+    }
+    printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
+
+    // clean up
+    for (int i = 0; i < _AVL; ++i){
+        for (int j=0; j<8; j++){
+            inp[i*8+j] = 0;
+        }
+        ind[i] = 0;
+        exp[i] = 0;
+        oup[i] = 0;
+    }
+    return err;
+}
+
 uint8_t test_st_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     uint32_t vl;
     uint32_t avl;
-    printf("[Index Store Tests: 16-bit ele, 8-bit index]\n");
+    printf("[Index Store Tests: 16-bit ele, 8-bit index] ");
     uint16_t  * inp = (uint16_t *)ref_inp;
     uint8_t   * ind = (uint8_t *)ref_ind;
     uint16_t  * oup = (uint16_t *)ref_oup;
@@ -400,16 +437,13 @@ uint8_t test_st_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
 
     // init vector
     for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
-    printf("[Init inp, done]\n");
     // init output
     for (int i = 0; i < 8 * _AVL; ++i) {
         oup[i] = 0;
         exp[i] = 0;
     }
-    printf("[Init exp, oup, done]\n");
     // init index
     for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
-    printf("[Init ind, done]\n");
     // calculate expected output
     for (int i = 0; i < _AVL; ++i){
         exp[ind[i]] = inp[i];
@@ -425,7 +459,6 @@ uint8_t test_st_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
         avl -= vl;
     } while (avl>0);
 
-    printf("[Check indexed load]\n");
     uint8_t err = 0;
     for (int i = 0; i < 8*_AVL; ++i){
         if (exp[i] != oup[i]){
@@ -434,11 +467,6 @@ uint8_t test_st_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
         } 
     }
     printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
-
-    // for(uint8_t i=0; i<2*_AVL; i++){
-    //     if (i%8==0) printf("\n");
-    //     printf("%4d", oup[i]);
-    // }
 
     // clean up
     for (int i = 0; i < _AVL; ++i){
@@ -452,6 +480,275 @@ uint8_t test_st_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     return err;
 }
 
+uint8_t test_st_ele32_index8(void * ref_inp, void * ref_ind, void * ref_oup){
+    uint32_t vl;
+    uint32_t avl;
+    printf("[Index Store Tests: 32-bit ele, 8-bit index] ");
+    uint32_t  * inp = (uint32_t *)ref_inp;
+    uint8_t   * ind = (uint8_t *)ref_ind;
+    uint32_t  * oup = (uint32_t *)ref_oup;
+    uint32_t  * exp = (uint32_t *)local(0x8000);
+
+    // init vector
+    for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
+    // init output
+    for (int i = 0; i < 8 * _AVL; ++i) {
+        oup[i] = 0;
+        exp[i] = 0;
+    }
+    // init index
+    for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
+    // calculate expected output
+    for (int i = 0; i < _AVL; ++i){
+        exp[ind[i]] = inp[i];
+    }
+
+    // index load
+    avl = _AVL;
+    do{
+        asm volatile("vsetvli %0, %1, e32, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        asm volatile("vle8.v  v0, (%0)" ::"r"(ind));
+        asm volatile("vle32.v v2, (%0)" ::"r"(inp));
+        asm volatile("vsuxei8.v v2, (%0), v0" ::"r"(oup));
+        avl -= vl;
+    } while (avl>0);
+
+    uint8_t err = 0;
+    for (int i = 0; i < 8*_AVL; ++i){
+        if (exp[i] != oup[i]){
+            err+=1;
+            printf("exp: %d, oup: %d\n", exp[i], oup[i]);
+        } 
+    }
+    printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
+
+    // clean up
+    for (int i = 0; i < _AVL; ++i){
+        for (int j=0; j<8; j++){
+            inp[i*8+j] = 0;
+        }
+        ind[i] = 0;
+        exp[i] = 0;
+        oup[i] = 0;
+    }
+    return err;
+}
+
+uint8_t test_st_ele64_index8(void * ref_inp, void * ref_ind, void * ref_oup){
+    uint32_t vl;
+    uint32_t avl;
+    printf("[Index Store Tests: 64-bit ele, 8-bit index] ");
+    uint64_t  * inp = (uint64_t *)ref_inp;
+    uint8_t   * ind = (uint8_t *)ref_ind;
+    uint64_t  * oup = (uint64_t *)ref_oup;
+    uint64_t  * exp = (uint64_t *)local(0x10000);
+
+    // init vector
+    for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
+    // init output
+    for (int i = 0; i < 8 * _AVL; ++i) {
+        oup[i] = 0;
+        exp[i] = 0;
+    }
+    // init index
+    for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
+    // calculate expected output
+    for (int i = 0; i < _AVL; ++i){
+        exp[ind[i]] = inp[i];
+    }
+
+    // index load
+    avl = _AVL;
+    do{
+        asm volatile("vsetvli %0, %1, e64, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        asm volatile("vle8.v  v0, (%0)" ::"r"(ind));
+        asm volatile("vle64.v v2, (%0)" ::"r"(inp));
+        asm volatile("vsuxei8.v v2, (%0), v0" ::"r"(oup));
+        avl -= vl;
+    } while (avl>0);
+
+    int8_t err = 0;
+    for (int i = 0; i < 8*_AVL; ++i){
+        if (exp[i] != oup[i]){
+            err = err + 1;
+            printf("exp: %d, oup: %d, err: %d\n", exp[i], oup[i], err);
+        } 
+    }
+    printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
+
+    // clean up
+    for (int i = 0; i < _AVL; ++i){
+        for (int j=0; j<8; j++){
+            inp[i*8+j] = 0;
+        }
+        ind[i] = 0;
+        exp[i] = 0;
+        oup[i] = 0;
+    }
+    return err;
+}
+
+uint8_t test_st_ele16_index16(void * ref_inp, void * ref_ind, void * ref_oup){
+    uint32_t vl;
+    uint32_t avl;
+    printf("[Index Store Tests: 16-bit ele, 16-bit index] ");
+    uint16_t  * inp = (uint16_t *)ref_inp;
+    uint16_t  * ind = (uint16_t *)ref_ind;
+    uint16_t  * oup = (uint16_t *)ref_oup;
+    uint16_t  * exp = (uint16_t *)local(0x8000);
+
+    // init vector
+    for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
+    // init output
+    for (int i = 0; i < 8 * _AVL; ++i) {
+        oup[i] = 0;
+        exp[i] = 0;
+    }
+    // init index
+    for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
+    // calculate expected output
+    for (int i = 0; i < _AVL; ++i){
+        exp[ind[i]] = inp[i];
+    }
+
+    // index load
+    avl = _AVL;
+    do{
+        asm volatile("vsetvli %0, %1, e16, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        asm volatile("vle16.v  v0, (%0)" ::"r"(ind));
+        asm volatile("vle16.v v2, (%0)" ::"r"(inp));
+        asm volatile("vsuxei16.v v2, (%0), v0" ::"r"(oup));
+        avl -= vl;
+    } while (avl>0);
+
+    uint8_t err = 0;
+    for (int i = 0; i < 8*_AVL; ++i){
+        if (exp[i] != oup[i]){
+            err+=1;
+            printf("exp: %d, oup: %d\n", exp[i], oup[i]);
+        } 
+    }
+    printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
+
+    // clean up
+    for (int i = 0; i < _AVL; ++i){
+        for (int j=0; j<8; j++){
+            inp[i*8+j] = 0;
+        }
+        ind[i] = 0;
+        exp[i] = 0;
+        oup[i] = 0;
+    }
+    return err;
+}
+
+uint8_t test_st_ele16_index32(void * ref_inp, void * ref_ind, void * ref_oup){
+    uint32_t vl;
+    uint32_t avl;
+    printf("[Index Store Tests: 16-bit ele, 32-bit index] ");
+    uint16_t  * inp = (uint16_t *)ref_inp;
+    uint32_t  * ind = (uint32_t *)ref_ind;
+    uint16_t  * oup = (uint16_t *)ref_oup;
+    uint16_t  * exp = (uint16_t *)local(0x8000);
+
+    // init vector
+    for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
+    // init output
+    for (int i = 0; i < 8 * _AVL; ++i) {
+        oup[i] = 0;
+        exp[i] = 0;
+    }
+    // init index
+    for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
+    // calculate expected output
+    for (int i = 0; i < _AVL; ++i){
+        exp[ind[i]] = inp[i];
+    }
+
+    // index load
+    avl = _AVL;
+    do{
+        asm volatile("vsetvli %0, %1, e16, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        asm volatile("vle32.v  v0, (%0)" ::"r"(ind));
+        asm volatile("vle16.v v2, (%0)" ::"r"(inp));
+        asm volatile("vsuxei32.v v2, (%0), v0" ::"r"(oup));
+        avl -= vl;
+    } while (avl>0);
+
+    uint8_t err = 0;
+    for (int i = 0; i < 8*_AVL; ++i){
+        if (exp[i] != oup[i]){
+            err+=1;
+            printf("exp: %d, oup: %d\n", exp[i], oup[i]);
+        } 
+    }
+    printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
+
+    // clean up
+    for (int i = 0; i < _AVL; ++i){
+        for (int j=0; j<8; j++){
+            inp[i*8+j] = 0;
+        }
+        ind[i] = 0;
+        exp[i] = 0;
+        oup[i] = 0;
+    }
+    return err;
+}
+
+uint8_t test_st_ele16_index64(void * ref_inp, void * ref_ind, void * ref_oup){
+    uint32_t vl;
+    uint32_t avl;
+    printf("[Index Store Tests: 16-bit ele, 64-bit index] ");
+    uint16_t  * inp = (uint16_t *)ref_inp;
+    uint64_t  * ind = (uint64_t *)ref_ind;
+    uint16_t  * oup = (uint16_t *)ref_oup;
+    uint16_t  * exp = (uint16_t *)local(0x8000);
+
+    // init vector
+    for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
+    // init output
+    for (int i = 0; i < 8 * _AVL; ++i) {
+        oup[i] = 0;
+        exp[i] = 0;
+    }
+    // init index
+    for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
+    // calculate expected output
+    for (int i = 0; i < _AVL; ++i){
+        exp[ind[i]] = inp[i];
+    }
+
+    // index load
+    avl = _AVL;
+    do{
+        asm volatile("vsetvli %0, %1, e16, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        asm volatile("vle64.v  v0, (%0)" ::"r"(ind));
+        asm volatile("vle16.v v2, (%0)" ::"r"(inp));
+        asm volatile("vsuxei64.v v2, (%0), v0" ::"r"(oup));
+        avl -= vl;
+    } while (avl>0);
+
+    uint8_t err = 0;
+    for (int i = 0; i < 8*_AVL; ++i){
+        if (exp[i] != oup[i]){
+            err+=1;
+            printf("exp: %d, oup: %d\n", exp[i], oup[i]);
+        } 
+    }
+    printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
+
+    // clean up
+    for (int i = 0; i < _AVL; ++i){
+        for (int j=0; j<8; j++){
+            inp[i*8+j] = 0;
+        }
+        ind[i] = 0;
+        exp[i] = 0;
+        oup[i] = 0;
+    }
+    return err;
+}
 
 void test_spatz_indexed(){
     flex_global_barrier_xy();//Global barrier
@@ -464,27 +761,41 @@ void test_spatz_indexed(){
         void * ref_inp = (void *)local(0x2000);
         void * ref_ind = (void *)local(0x4000);
         void * ref_oup = (void *)local(0x6000);
-        // tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele8_index8(ref_inp, ref_ind, ref_oup);
         tot_err += test_st_ele16_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele32_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele64_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele16_index16(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele16_index32(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele16_index64(ref_inp, ref_ind, ref_oup);
 
-        // ref_inp = (void *)local(0x2003);
-        // tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
+        ref_inp = (void *)local(0x2003);
+        tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele8_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele16_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele32_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele64_index8(ref_inp, ref_ind, ref_oup);
 
-        // ref_inp = (void *)local(0x2000);
-        // ref_ind = (void *)local(0x4005);
-        // tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
-        // tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
+        ref_inp = (void *)local(0x2000);
+        ref_ind = (void *)local(0x4005);
+        tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele8_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele16_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele32_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele64_index8(ref_inp, ref_ind, ref_oup);
 
         printf(">>> tot_error: %d\n", tot_err);
     }

--- a/examples/SoftHier/software/spatz_check/include/spatz_indexed_check.h
+++ b/examples/SoftHier/software/spatz_check/include/spatz_indexed_check.h
@@ -5,7 +5,7 @@
 #include "flex_printf.h"
 #include "flex_libfp16.h"
 
-#define _AVL (256)
+#define _AVL (64)
 #pragma GCC optimize("no-tree-loop-distribute-patterns")
 
 void l1_layout(uint8_t *addr, uint8_t size){ // size in byte
@@ -388,6 +388,71 @@ uint8_t test_ele64_index8(void * ref_inp, void * ref_ind, void * ref_oup){
     return err;
 }
 
+// index store
+uint8_t test_st_ele16_index8(void * ref_inp, void * ref_ind, void * ref_oup){
+    uint32_t vl;
+    uint32_t avl;
+    printf("[Index Store Tests: 16-bit ele, 8-bit index]\n");
+    uint16_t  * inp = (uint16_t *)ref_inp;
+    uint8_t   * ind = (uint8_t *)ref_ind;
+    uint16_t  * oup = (uint16_t *)ref_oup;
+    uint16_t  * exp = (uint16_t *)local(0x8000);
+
+    // init vector
+    for (int i = 0; i < _AVL; ++i) inp[i] = i+1;
+    printf("[Init inp, done]\n");
+    // init output
+    for (int i = 0; i < 8 * _AVL; ++i) {
+        oup[i] = 0;
+        exp[i] = 0;
+    }
+    printf("[Init exp, oup, done]\n");
+    // init index
+    for (int i = 0; i < _AVL; ++i) ind[i] = 3*i+1;
+    printf("[Init ind, done]\n");
+    // calculate expected output
+    for (int i = 0; i < _AVL; ++i){
+        exp[ind[i]] = inp[i];
+    }
+
+    // index load
+    avl = _AVL;
+    do{
+        asm volatile("vsetvli %0, %1, e16, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        asm volatile("vle8.v  v0, (%0)" ::"r"(ind));
+        asm volatile("vle16.v v2, (%0)" ::"r"(inp));
+        asm volatile("vsuxei8.v v2, (%0), v0" ::"r"(oup));
+        avl -= vl;
+    } while (avl>0);
+
+    printf("[Check indexed load]\n");
+    uint8_t err = 0;
+    for (int i = 0; i < 8*_AVL; ++i){
+        if (exp[i] != oup[i]){
+            err+=1;
+            printf("exp: %d, oup: %d\n", exp[i], oup[i]);
+        } 
+    }
+    printf(">>> %d error(s) out of %d checks\n\n", err, _AVL);
+
+    // for(uint8_t i=0; i<2*_AVL; i++){
+    //     if (i%8==0) printf("\n");
+    //     printf("%4d", oup[i]);
+    // }
+
+    // clean up
+    for (int i = 0; i < _AVL; ++i){
+        for (int j=0; j<8; j++){
+            inp[i*8+j] = 0;
+        }
+        ind[i] = 0;
+        exp[i] = 0;
+        oup[i] = 0;
+    }
+    return err;
+}
+
+
 void test_spatz_indexed(){
     flex_global_barrier_xy();//Global barrier
     if (flex_get_core_id() == 0 && flex_get_cluster_id() == 0)
@@ -399,26 +464,27 @@ void test_spatz_indexed(){
         void * ref_inp = (void *)local(0x2000);
         void * ref_ind = (void *)local(0x4000);
         void * ref_oup = (void *)local(0x6000);
-        tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
+        tot_err += test_st_ele16_index8(ref_inp, ref_ind, ref_oup);
 
-        ref_inp = (void *)local(0x2003);
-        tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
+        // ref_inp = (void *)local(0x2003);
+        // tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele8_index16(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele8_index32(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele8_index64(ref_inp, ref_ind, ref_oup);
 
-        ref_inp = (void *)local(0x2000);
-        ref_ind = (void *)local(0x4005);
-        tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
-        tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
+        // ref_inp = (void *)local(0x2000);
+        // ref_ind = (void *)local(0x4005);
+        // tot_err += test_ele8_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele16_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele32_index8(ref_inp, ref_ind, ref_oup);
+        // tot_err += test_ele64_index8(ref_inp, ref_ind, ref_oup);
 
         printf(">>> tot_error: %d\n", tot_err);
     }

--- a/examples/SoftHier/software/spatz_check/main.c
+++ b/examples/SoftHier/software/spatz_check/main.c
@@ -2,6 +2,7 @@
 #include "spatz_check.h"
 #include "spatz_indexed_check.h"
 #include "spatz_fp8_check.h"
+#include "spatz_custom_isa.h"
 #include <math.h>
 
 int main()
@@ -16,6 +17,7 @@ int main()
     test_spatz();
     test_spatz_indexed();
     test_spatz_fp8();
+    test_spatz_isa();
     /**************************************/
     /*  Program Execution Region -- Stop  */
     /**************************************/

--- a/examples/SoftHier/software/spatz_check/util/spatz_datagen.py
+++ b/examples/SoftHier/software/spatz_check/util/spatz_datagen.py
@@ -15,66 +15,7 @@
 import os
 import numpy as np
 import argparse
-
-def float_to_fp8_e4m3(val):
-    """Encode float16 value into simulated fp8 (E4M3) format (bias=7, 4 exponent bits, 3 mantissa bits)."""
-    f16 = np.float16(val)
-    b = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
-
-    sign = (b >> 15) & 0x1
-    exp  = (b >> 10) & 0x1F  # 5-bit exponent
-    frac = (b >> 7)  & 0x7   # top 3 mantissa bits
-
-    if exp == 0 and frac == 0:
-        return 0x00
-    elif exp == 0x1F:
-        return 0x7F if sign == 0 else 0xFF  # Inf or NaN
-
-    fp8_exp = exp - 15 + 7  # Bias shift: float16 bias=15, E4M3 bias=7
-    if fp8_exp <= 0:
-        return 0x00  # Underflow to zero
-    elif fp8_exp >= 0xF:
-        return 0x7F if sign == 0 else 0xFF  # Overflow to max
-
-    result = (sign << 7) | ((fp8_exp & 0xF) << 3) | (frac & 0x7)
-    return result
-
-def float_to_fp8_e5m2(val):
-    """Encode float16 value into simulated fp8 (E5M2) format (bias=15, 5 exponent bits, 2 mantissa bits)."""
-    f16 = np.float16(val)
-    b = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
-
-    sign = (b >> 15) & 0x1
-    exp  = (b >> 10) & 0x1F  # 5-bit exponent
-    frac = (b >> 8)  & 0x3   # top 2 mantissa bits
-
-    if exp == 0 and frac == 0:
-        return 0x00
-    elif exp == 0x1F:
-        return 0x7F if sign == 0 else 0xFF  # Inf or NaN
-
-    result = (sign << 7) | ((exp & 0x1F) << 2) | (frac & 0x3)
-    return result
-
-def generate_fp8_matrix(rows, cols):
-    """Generate a matrix with values in the range [-1, 1], stored in float16."""
-    return np.random.uniform(-1.0, 1.0, size=(rows, cols)).astype(np.float16)
-
-def write_matrix_to_header(f, name, mat, fmt='e4m3', dtype='uint8_t'):
-    """Write a flattened matrix to C header as uint8_t fp8-encoded values."""
-    flat = mat.flatten()
-    f.write(f'static const {dtype} {name}[{len(flat)}] = {{\n')
-    for i, val in enumerate(flat):
-        if fmt == 'e4m3':
-            int_val = float_to_fp8_e4m3(val)
-        elif fmt == 'e5m2':
-            int_val = float_to_fp8_e5m2(val)
-        else:
-            raise ValueError(f"Unsupported format: {fmt}")
-        f.write(f'  0x{int_val:02X},')
-        if (i + 1) % 8 == 0:
-            f.write('\n')
-    f.write('};\n\n')
+from flex_libfp8 import generate_fp8_matrix, write_matrix_to_header
 
 def main():
     parser = argparse.ArgumentParser(description='FP8 Tensor Generator')

--- a/examples/SoftHier/software/spatz_check/util/spatz_datagen.py
+++ b/examples/SoftHier/software/spatz_check/util/spatz_datagen.py
@@ -63,6 +63,7 @@ def main():
         write_matrix_to_header(f, 'vector_a_fp8', A, fmt=args.format)
         write_matrix_to_header(f, 'vector_b_fp8', B, fmt=args.format)
         write_matrix_to_header(f, 'vector_c_fp8', C, fmt=args.format)
+        write_matrix_to_header(f, 'vector_c_fp16', C, fmt='fp16', dtype='uint16_t') # for widening instructions
         write_matrix_to_header(f, 's_fp8', S, fmt=args.format)
         
         write_matrix_to_header(f, 'vector_c_add_vv_fp8', C_add_vv, fmt=args.format)
@@ -78,6 +79,12 @@ def main():
         write_matrix_to_header(f, 'vector_c_mul_vf_fp8', C_mul_vf, fmt=args.format)
         write_matrix_to_header(f, 'vector_c_madd_vf_fp8', C_madd_vf, fmt=args.format)
         write_matrix_to_header(f, 'vector_c_macc_vf_fp8', C_macc_vf, fmt=args.format)
+        
+        # widening instructions
+        write_matrix_to_header(f, 'vector_c_wadd_vf_fp8', C_add_vf, fmt='fp16', dtype='uint16_t')
+        write_matrix_to_header(f, 'vector_c_wsub_vf_fp8', C_sub_vf, fmt='fp16', dtype='uint16_t')
+        write_matrix_to_header(f, 'vector_c_wmul_vf_fp8', C_mul_vf, fmt='fp16', dtype='uint16_t')
+        write_matrix_to_header(f, 'vector_c_wmacc_vf_fp8', C_macc_vf, fmt='fp16', dtype='uint16_t')
 
         f.write('#endif // SPATZ_CHECK_DATA_FP8_H\n')
 

--- a/examples/SoftHier/software/spatz_check/util/spatz_datagen.py
+++ b/examples/SoftHier/software/spatz_check/util/spatz_datagen.py
@@ -52,7 +52,7 @@ def main():
     script_dir = os.path.dirname(os.path.realpath(__file__))
     include_dir = os.path.abspath(os.path.join(script_dir, '..', 'include'))
     os.makedirs(include_dir, exist_ok=True)
-    header_path = os.path.join(include_dir, 'spatz_fp8_check_data.h')
+    header_path = os.path.join(include_dir, 'data_spatz_fp8_check.h')
 
     with open(header_path, 'w') as f:
         f.write('#ifndef SPATZ_CHECK_DATA_FP8_H\n')

--- a/soft_hier/flex_cluster_sdk/runtime/include/flex_libfp8.h
+++ b/soft_hier/flex_cluster_sdk/runtime/include/flex_libfp8.h
@@ -60,7 +60,7 @@ float fp8_e5m2_to_f32(uint8_t val) {
     return sign ? -result : result;
 }
 
-void spatz_verify(uint32_t avl, uint8_t* act_vec, uint8_t* exp_vec) {
+void spatz_verify(uint32_t avl, uint8_t* act_vec, uint8_t* exp_vec, const float tol) {
     uint8_t exp_fp8, act_fp8;
     float exp_f32, act_f32;
     uint32_t tot_err = 0;
@@ -77,14 +77,14 @@ void spatz_verify(uint32_t avl, uint8_t* act_vec, uint8_t* exp_vec) {
         //            i, exp_fp8, exp_f32, act_fp8, act_f32, err);
         //     tot_err += 1;
         // }
-        if (err > 0.25f || err < -0.25f) {
+        if (err > tol || err < -tol) {
             printf("%3d | exp: 0x%02x (%.5f), act: 0x%02x (%.5f), err: %.5f\n",
                    i, exp_fp8, exp_f32, act_fp8, act_f32, err);
             tot_err += 1;
         }
     }
 
-    printf("Errors above threshold (E5M2: 0.25f): %d out of %d\n", tot_err, avl);
+    printf("Errors above threshold (E5M2: %3ff): %d out of %d\n", tol, tot_err, avl);
 }
 
 #endif

--- a/soft_hier/flex_cluster_utilities/flex_libfp8.py
+++ b/soft_hier/flex_cluster_utilities/flex_libfp8.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# Copyright 2025 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Author: Bowen Wang, ETH Zurich
+# This script includes FP8 common functions for data generation
+
+import numpy as np
+
+#########################################################
+#                  Format transform
+# float_to_fp8_e4m3():        Scalar np.float16 --> fp8 (E4M3)
+# float_to_fp8_e5m2():        Scalar np.float16 --> fp8 (E5M2)
+# fp8_e5m2_to_fp16():         Scalar fp8 (E5M2) --> np.float16
+# float_to_fp16():            Scalar np.float16 --> fp16 (E5M10)
+# matrix_float_to_fp8_e5m2(): Matrix np.float16 --> fp8 (E5M2)
+# matrix_fp8_e5m2_to_fp16():  Matrix fp8 (E5M2) --> np.float16
+
+
+def float_to_fp8_e4m3(val):
+    """Encode float16 value into simulated fp8 (E4M3) format (bias=7, 4 exponent bits, 3 mantissa bits)."""
+    f16 = np.float16(val)
+    b = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
+
+    sign = (b >> 15) & 0x1
+    exp  = (b >> 10) & 0x1F  # 5-bit exponent
+    frac = (b >> 7)  & 0x7   # top 3 mantissa bits
+
+    if exp == 0 and frac == 0:
+        return 0x00
+    elif exp == 0x1F:
+        return 0x7F if sign == 0 else 0xFF  # Inf or NaN
+
+    fp8_exp = exp - 15 + 7  # Bias shift: float16 bias=15, E4M3 bias=7
+    if fp8_exp <= 0:
+        return 0x00  # Underflow to zero
+    elif fp8_exp >= 0xF:
+        return 0x7F if sign == 0 else 0xFF  # Overflow to max
+
+    result = (sign << 7) | ((fp8_exp & 0xF) << 3) | (frac & 0x7)
+    return result
+
+def float_to_fp8_e5m2(val):
+    """Encode float16 value into simulated fp8 (E5M2) format (bias=15, 5 exponent bits, 2 mantissa bits)."""
+    f16 = np.float16(val)
+    b = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
+
+    sign = (b >> 15) & 0x1
+    exp  = (b >> 10) & 0x1F  # 5-bit exponent
+    frac = (b >> 8)  & 0x3   # top 2 mantissa bits
+
+    if exp == 0 and frac == 0:
+        return 0x00
+    elif exp == 0x1F:
+        return 0x7F if sign == 0 else 0xFF  # Inf or NaN
+
+    result = (sign << 7) | ((exp & 0x1F) << 2) | (frac & 0x3)
+    return result
+
+def fp8_e5m2_to_fp16(fp8):
+    """Decode 8-bit FP8 E5M2 (bias=15) value into a NumPy float16."""
+    fp8 = int(fp8) & 0xFF  # ensure 8-bit
+
+    sign = (fp8 >> 7) & 0x1
+    exp  = (fp8 >> 2) & 0x1F  # 5-bit exponent
+    frac = fp8 & 0x3          # 2-bit mantissa
+
+    if exp == 0 and frac == 0:
+        return np.float16(-0.0 if sign else 0.0)
+    elif exp == 0x1F:
+        # Inf or NaN
+        return np.float16('-inf') if sign else np.float16('inf')
+
+    # Reconstruct mantissa: 1 + frac / 4.0
+    mant = 1.0 + (frac / 4.0)
+    exp_val = exp - 15  # bias = 15
+
+    # Scale by 2^exp_val without math.pow
+    scale = 1.0
+    if exp_val >= 0:
+        for _ in range(exp_val):
+            scale *= 2.0
+    else:
+        for _ in range(-exp_val):
+            scale *= 0.5
+
+    val = mant * scale
+    return np.float16(-val if sign else val)
+
+def float_to_fp16(val):
+    """Encode a float32 or float64 value into simulated fp16 (IEEE 754, E5M10) format (bias=15)."""
+    f16 = np.float16(val)
+    b = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
+
+    sign = (b >> 15) & 0x1
+    exp  = (b >> 10) & 0x1F  # 5-bit exponent
+    frac = b & 0x3FF         # 10-bit mantissa
+
+    # Compose back into 16-bit integer FP16 format
+    result = (sign << 15) | (exp << 10) | frac
+    return result
+
+def matrix_float_to_fp8_e5m2(val):
+    """Vectorized: Encode float16 NumPy array into FP8 E5M2 (as uint8 array)."""
+    f16 = val.astype(np.float16)
+    b = f16.view(np.uint16)
+
+    sign = (b >> 15) & 0x1
+    exp  = (b >> 10) & 0x1F
+    frac = (b >> 8)  & 0x3
+
+    # Create empty output array
+    out = np.zeros_like(exp, dtype=np.uint8)
+
+    # Zero
+    zero_mask = (exp == 0) & (frac == 0)
+    out[zero_mask] = 0x00
+
+    # Inf or NaN
+    inf_mask = (exp == 0x1F)
+    out[inf_mask] = np.where(sign[inf_mask] == 0, 0x7F, 0xFF)
+
+    # Normal values
+    norm_mask = ~(zero_mask | inf_mask)
+    out[norm_mask] = ((sign[norm_mask] << 7) |
+                      (exp[norm_mask] << 2) |
+                      (frac[norm_mask]))
+
+    return out
+
+def matrix_fp8_e5m2_to_fp16(fp8):
+    """Vectorized: Decode FP8 E5M2 NumPy array (uint8) into float16."""
+    fp8 = fp8.astype(np.uint8)
+
+    sign = (fp8 >> 7) & 0x1
+    exp  = (fp8 >> 2) & 0x1F
+    frac = fp8 & 0x3
+
+    result = np.zeros_like(fp8, dtype=np.float16)
+
+    # Zero
+    zero_mask = (exp == 0) & (frac == 0)
+    result[zero_mask] = np.where(sign[zero_mask], -0.0, 0.0).astype(np.float16)
+
+    # Inf
+    inf_mask = (exp == 0x1F)
+    result[inf_mask] = np.where(sign[inf_mask], -np.inf, np.inf).astype(np.float16)
+
+    # Normal values
+    norm_mask = ~(zero_mask | inf_mask)
+    mant = 1.0 + (frac[norm_mask] / 4.0)
+    exp_val = exp[norm_mask].astype(np.int32) - 15
+    scale = np.power(2.0, exp_val).astype(np.float32)
+    val = mant * scale
+    result[norm_mask] = np.where(sign[norm_mask], -val, val).astype(np.float16)
+
+    return result
+
+################################################################
+#                      Data Generation
+# generate_fp8_matrix(): generate a fp16-represented fp8 matrix 
+#                        with specified scales
+
+def generate_fp8_matrix(rows, cols):
+    """Generate a matrix with values in the range [-1, 1], stored in float16."""
+    matrix_fp16_ori = np.random.uniform(-1.0, 1.0, size=(rows, cols)).astype(np.float16)
+    fp8_encoded = matrix_float_to_fp8_e5m2(matrix_fp16_ori)
+    matrix_fp16_cast = matrix_fp8_e5m2_to_fp16(fp8_encoded)
+    return matrix_fp16_cast.astype(np.float16)
+
+################################################################
+#                    Data Dump to Header
+# write_matrix_to_header(): wrapper for data dump
+#
+# example usage: write_matrix_to_header(f, 'matrix_c_name', C, fmt='fp16', dtype='uint16_t')
+#                write_matrix_to_header(f, 'matrix_c_name', C, fmt='e5m2', dtype='uint8_t')
+
+def write_matrix_to_header(f, name, mat, fmt='e4m3', dtype='uint8_t'):
+    """Write a flattened matrix to C header as uint8_t fp8-encoded values."""
+    flat = mat.flatten()
+    f.write(f'static const {dtype} {name}[{len(flat)}] = {{\n')
+    for i, val in enumerate(flat):
+        if fmt == 'e4m3':
+            int_val = float_to_fp8_e4m3(val)
+            f.write(f'  0x{int_val:02X},')
+        elif fmt == 'e5m2':
+            int_val = float_to_fp8_e5m2(val)
+            f.write(f'  0x{int_val:02X},')
+        elif fmt == 'fp16':
+            int_val = float_to_fp16(val)
+            f.write(f'  0x{int_val:04X},')
+        else:
+            raise ValueError(f"Unsupported format: {fmt}")
+        if (i + 1) % 8 == 0:
+            f.write('\n')
+    f.write('};\n\n')

--- a/soft_hier/flex_cluster_utilities/flex_libfp8.py
+++ b/soft_hier/flex_cluster_utilities/flex_libfp8.py
@@ -185,7 +185,7 @@ def generate_fp8_matrix(rows, cols):
 def write_matrix_to_header(f, name, mat, fmt='e4m3', dtype='uint8_t'):
     """Write a flattened matrix to C header as uint8_t fp8-encoded values."""
     flat = mat.flatten()
-    f.write(f'static const {dtype} {name}[{len(flat)}] = {{\n')
+    f.write(f'__attribute__((section(".hbm"))) static const {dtype} {name}[{len(flat)}] = {{\n')
     for i, val in enumerate(flat):
         if fmt == 'e4m3':
             int_val = float_to_fp8_e4m3(val)

--- a/soft_hier/flex_cluster_utilities/flex_libfp8.py
+++ b/soft_hier/flex_cluster_utilities/flex_libfp8.py
@@ -275,6 +275,7 @@ def write_index_to_header(f, name, mat, fmt='nm2bit', dtype='uint8_t'):
     if fmt == 'nm2bit':
         # Check that number of elements is divisible by 4
         assert len(flat) % 4 == 0, "Length of index matrix must be divisible by 4 for 2-bit packing"
+        f.write(f'#define _IDX_PER_BYTE (4)\n\n')
 
         packed = []
         for i in range(0, len(flat), 4):

--- a/soft_hier/gvsoc_core.patch
+++ b/soft_hier/gvsoc_core.patch
@@ -166,7 +166,7 @@ index 00000000..fde9d634
 +    return iss_insn_next(iss, insn, pc);
 +}
 diff --git a/models/cpu/iss/include/isa/rv32v.hpp b/models/cpu/iss/include/isa/rv32v.hpp
-index 188f2877..61c7bb2a 100644
+index 188f2877..4a1f54ad 100644
 --- a/models/cpu/iss/include/isa/rv32v.hpp
 +++ b/models/cpu/iss/include/isa/rv32v.hpp
 @@ -20,8 +20,24 @@
@@ -842,6 +842,26 @@ index 188f2877..61c7bb2a 100644
      return iss_insn_next(iss, insn, pc);
  }
  
+@@ -1005,7 +1284,19 @@ static inline iss_reg_t vfncvt_rtz_x_f_w_exec(Iss *iss, iss_insn_t *insn, iss_re
+ 
+ 
+ 
++// index scalar-vector multiplication
++static inline iss_reg_t vfwxmul_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
++    LIB_CALL5(lib_FWXMULVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
++    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU);
++    uint64_t delay = iss->spatz.timing_insn(insn, 0, REG_OUT(0), REG_IN(2), REG_IN(1), latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
++    return iss_insn_next(iss, insn, pc);
++}
+ 
++static inline iss_reg_t vfwxmacc_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
++    LIB_CALL5(lib_FWXMACCVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
++    return iss_insn_next(iss, insn, pc);
++}
+ 
+ 
+ 
 diff --git a/models/cpu/iss/include/isa/xdma.hpp b/models/cpu/iss/include/isa/xdma.hpp
 index 84e01c06..cadf5f31 100644
 --- a/models/cpu/iss/include/isa/xdma.hpp
@@ -856,7 +876,7 @@ index 84e01c06..cadf5f31 100644
      IssOffloadInsn<iss_reg_t> offload_insn = {
          .opcode=insn->opcode,
 diff --git a/models/cpu/iss/include/isa_lib/vint.h b/models/cpu/iss/include/isa_lib/vint.h
-index 26cb748e..f89e2b3d 100644
+index 26cb748e..ed727c13 100644
 --- a/models/cpu/iss/include/isa_lib/vint.h
 +++ b/models/cpu/iss/include/isa_lib/vint.h
 @@ -31,6 +31,12 @@
@@ -958,7 +978,7 @@ index 26cb748e..f89e2b3d 100644
 +static inline void lib_VIDV    (Iss *iss, int vs2, int64_t rs1, int vd, bool vm){
 +
 +    for (int i = VSTART; i < VL; i++){
- 
++
 +        int32_t val = i;
 +        bool resBin[64];
 +
@@ -968,7 +988,7 @@ index 26cb748e..f89e2b3d 100644
 +
 +    }
 +}
- 
++
 +static inline void lib_SLLVV    (Iss *iss, int vs1, int vs2    , int vd, bool vm){
 +    int64_t data1, data2, res;
 +    bool bin[8];
@@ -978,11 +998,11 @@ index 26cb748e..f89e2b3d 100644
 +        if(!(i%8)){
 +            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
 +        }
-+
+ 
 +        myAbs(iss, SEW, vs1, i, &data1);
 +        myAbs(iss, SEW, vs2, i, &data2);
 +        res = data2 << data1;
-+
+ 
 +        intToBin(SEW, abs(res), resBin);
 +        if(res < 0){
 +            twosComplement(SEW, resBin);
@@ -1308,8 +1328,7 @@ index 26cb748e..f89e2b3d 100644
 -    uint8_t data[4];
 -
 -
-+    uint8_t data[INTF_WIDTH];
- 
+-
 -    int align = 0;
 -    if(start_add%4 == 1){
 -        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
@@ -1329,7 +1348,8 @@ index 26cb748e..f89e2b3d 100644
 -    }else if(start_add%4 == 3){
 -        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
 -        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
--
++    uint8_t data[INTF_WIDTH];
+ 
 -        start_add += 1;
 -        align = 1;
 -    }else{
@@ -1548,14 +1568,14 @@ index 26cb748e..f89e2b3d 100644
 -        // printf("data3 = %d\n",data[3]);
 -
 -        //printf("vd = %d\n",vd);
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
- 
+-
 -        //iss->spatz.vregfile.vregs[vd][i+0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? (data[1]*pow(2,8) + data[0]) : iss->spatz.vregfile.vregs[vd][i+0];
 -        //iss->spatz.vregfile.vregs[vd][i+1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? (data[3]*pow(2,8) + data[2]) : iss->spatz.vregfile.vregs[vd][i+1];
 -
 -        // iss->spatz.vregfile.vregs[vd][i+0] = (data[1]*pow(2,8) + data[0]);
 -        // iss->spatz.vregfile.vregs[vd][i+1] = (data[3]*pow(2,8) + data[2]);
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
+ 
 -        iss->spatz.vregfile.vregs[vd][i+0] = data[0];
 -        iss->spatz.vregfile.vregs[vd][i+1] = data[1];
 -        iss->spatz.vregfile.vregs[vd][i+2] = data[2];
@@ -1638,8 +1658,7 @@ index 26cb748e..f89e2b3d 100644
 -        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
 -        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+2]%2)) ? iss->spatz.vregfile.vregs[vs3][i+2] : 0;
 -        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+3]%2)) ? iss->spatz.vregfile.vregs[vs3][i+3] : 0;
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL; i+=INTF_WIDTH){
- 
+-
 -        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
@@ -1653,7 +1672,8 @@ index 26cb748e..f89e2b3d 100644
 -        // printf("data3  = %d\n",data[3 ]);
 -
 -        // printf("addr  = %lu\n",start_add);
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL; i+=INTF_WIDTH){
+ 
 -        //if(!i){
 -            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
 -        //}else{
@@ -1728,14 +1748,14 @@ index 26cb748e..f89e2b3d 100644
 -        // }else{
 -        //     vlsu.handle_pending_io_access(iss);
 -        // }
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
- 
+-
 -        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
 -        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
 -        // printf("i = %d\t,vd = %d\n",i,vs3);
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
+ 
 -        // printf("STORE16 \n");
 -        // printf("data0  = %d\n",data[0]);
 -        // printf("data1  = %d\n",data[1]);
@@ -2012,12 +2032,6 @@ index 26cb748e..f89e2b3d 100644
 -    while(i < VL*2){
 -        if(!((i/2)%8)){
 -            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/2)/8],bin);
--        }
--        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
--        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
--        if(!(!(vm) && !bin[(i/2+0)%8])){
--            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
--            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
 +    for (int i=0; i < VL; i+=1){
 +        // read index
 +        index[0] = iss->spatz.vregfile.vregs[vs2][i];
@@ -2032,6 +2046,12 @@ index 26cb748e..f89e2b3d 100644
 +        for (int j=0; j<sew_bytes; j++){
 +            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
          }
+-        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
+-        if(!(!(vm) && !bin[(i/2+0)%8])){
+-            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
+-        }
 -        i+=2;
      }
  }
@@ -2098,7 +2118,11 @@ index 26cb748e..f89e2b3d 100644
 -    while(i < VL*8){
 -        if(!((i/8)%8)){
 -            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/8)/8],bin);
--        }
++    for (int i=0; i < VL; i+=1){
++        // read index
++        for (int k=0; k<4; k++){
++            index[k] = iss->spatz.vregfile.vregs[vs2][i*4+k];
+         }
 -    
 -        if(flag){
 -            flag = 0;
@@ -2108,11 +2132,7 @@ index 26cb748e..f89e2b3d 100644
 -            flag = 1;
 -            index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
 -            iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
-+    for (int i=0; i < VL; i+=1){
-+        // read index
-+        for (int k=0; k<4; k++){
-+            index[k] = iss->spatz.vregfile.vregs[vs2][i*4+k];
-         }
+-        }
 -        if(!(!(vm) && !bin[(i/8+0)%8])){
 -            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
 -            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
@@ -2127,9 +2147,9 @@ index 26cb748e..f89e2b3d 100644
 +            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
          }
 -        i+=4;
--    }
--}
--
+     }
+ }
+ 
 -static inline void lib_VLUXEIV  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, int EEW){
 -    float temp = float(SEW)/float(EEW);
 -    if(SEW == 8){
@@ -2140,9 +2160,9 @@ index 26cb748e..f89e2b3d 100644
 -        lib_VLUXEI32V  (iss, rs1, vs2, vd , vm, temp);
 -    }else if(SEW == 64){
 -        lib_VLUXEI64V  (iss, rs1, vs2, vd , vm, temp);
-     }
- }
- 
+-    }
+-}
+-
 -
 -static inline void lib_VSUXEI8V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
 +static inline void lib_VLUXEI64V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
@@ -2455,7 +2475,7 @@ index 26cb748e..f89e2b3d 100644
  
  
  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-@@ -6943,6 +6894,7 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
+@@ -6943,9 +6894,125 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
          }else{
              AVL = VL;
          }
@@ -2463,6 +2483,125 @@ index 26cb748e..f89e2b3d 100644
      return VL;
      }
  }
+ 
++// In N:M format, we assume each index cannot exceed 8-bit
++// size could be [1, 2, 4]
++static inline void myAbsINDEX(Iss *iss,int size, int vs, int i, uint64_t* data){
++    iss_Vel_t byte, temp;
++    int num_idx_per_byte = 8/size;
++    int byte_offset  = i / num_idx_per_byte;
++    int index_offset = (i % num_idx_per_byte) * size;
++
++    if (!(size == 1 || size == 2 || size == 4)) {
++        // sanity check
++        printf("INVALID INDEX BIT WIDTH (%d)! Must be 1, 2, or 4.\n", size);
++    } else {
++        // read corresponding byte
++        byte = iss->spatz.vregfile.vregs[vs][byte_offset];
++        // Extract 'size'-bit value at index_offset
++        temp = (byte >> index_offset) & ((1 << size) - 1);
++        // assign value
++        *data = (uint64_t)temp;
++    }
++}
++
++// index-mul.vf implementation
++// currently support 2-bit indices for X:4 format
++#define INDEX_BITS (2)
++#define SP_N (2)
++#define SP_M (4)
++static inline void lib_FWXMULVF  (Iss *iss, int vs2, int vs1, int64_t rs1, int vd, bool vm){
++    bool bin[8];
++    unsigned long int res, data1, data2, index;
++    uint8_t e, m;
++    uint8_t e2, m2;
++    bool resBin[64];
++    data1 = rs1; // UINT represented FP
++
++    for (int i = VSTART; i < VL; i++){
++        if(!(i%8)){
++            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
++        }
++        // 1. read index 
++        myAbsINDEX(iss, INDEX_BITS, vs1, i, &index);
++        // printf("index: %x\n", index);
++        // 2. read vecotr FP element
++        myAbsU(iss, SEW, vs2, i, &data2);
++        EMCase(SEW, &m, &e);
++        EMCase(SEW*2, &m2, &e2);
++        // 3. N:M block info
++        int block_idx = i / SP_N * SP_M;
++
++        if(!mask(vm,bin)){
++            int old = setFFRoundingMode(iss, iss->csr.fcsr.frm);
++            flexfloat_t ff_a, ff_b, ff_res;
++            flexfloat_desc_t env = (flexfloat_desc_t){e, m};
++            flexfloat_desc_t env2 = (flexfloat_desc_t){e2, m2};
++            ff_init(&ff_a, env);
++            ff_init(&ff_b, env);
++            ff_init(&ff_res, env2);
++            flexfloat_set_bits(&ff_a, data1);
++            flexfloat_set_bits(&ff_b, data2);
++            feclearexcept(FE_ALL_EXCEPT);
++            ff_mul(&ff_res, &ff_a, &ff_b);
++            update_fflags_fenv(iss);
++            res = flexfloat_get_bits(&ff_res);
++            restoreFFRoundingMode(old);
++            intToBinU(SEW*2, res, resBin);
++            writeToVReg(iss, SEW*2, vd, block_idx + index, resBin);
++        }
++    }
++}
++
++static inline void lib_FWXMACCVF  (Iss *iss, int vs2, int vs1, int64_t rs1, int vd, bool vm){
++    bool bin[8];
++    unsigned long int res, data1, data2, data3, index;
++    uint8_t e, m;
++    uint8_t e2, m2;
++    bool resBin[64];
++    data1 = rs1; // scalar
++    for (int i = VSTART; i < VL; i++){
++        if(!(i%8)){
++            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
++        }
++        // 0. N:M block info
++        int block_idx = i / SP_N * SP_M;
++        // 1. read index 
++        myAbsINDEX(iss, INDEX_BITS, vs1, i, &index);
++        // 2. read vecotr FP element
++        myAbsU(iss, SEW, vs2, i, &data2);
++        // gather acc value
++        myAbsU(iss, SEW*2, vd , block_idx + index, &data3);
++
++        EMCase(SEW, &m, &e);
++        EMCase(SEW*2, &m2, &e2);
++
++        if(!mask(vm,bin)){
++            int old = setFFRoundingMode(iss, iss->csr.fcsr.frm);
++            flexfloat_t ff_a, ff_b, ff_c, ff_res;
++            flexfloat_desc_t env = (flexfloat_desc_t){e, m};
++            flexfloat_desc_t env2 = (flexfloat_desc_t){e2, m2};
++            ff_init(&ff_a, env);
++            ff_init(&ff_b, env);
++            ff_init(&ff_c, env2);
++            ff_init(&ff_res, env2);
++            flexfloat_set_bits(&ff_a, data1);
++            flexfloat_set_bits(&ff_b, data2);
++            flexfloat_set_bits(&ff_c, data3);
++            feclearexcept(FE_ALL_EXCEPT);
++            ff_macc(&ff_res, &ff_a, &ff_b, &ff_c);
++            update_fflags_fenv(iss);
++            res = flexfloat_get_bits(&ff_res);
++            restoreFFRoundingMode(old);
++            intToBinU(SEW*2, res, resBin);
++            writeToVReg(iss, SEW*2, vd, block_idx + index, resBin);
++        }
++    }
++}
++
+ 
+ #endif 
+\ No newline at end of file
 diff --git a/models/cpu/iss/include/spatz.hpp b/models/cpu/iss/include/spatz.hpp
 index 8b348cd0..3a95941f 100644
 --- a/models/cpu/iss/include/spatz.hpp
@@ -2513,10 +2652,24 @@ index 8b348cd0..3a95941f 100644
  };
  
 diff --git a/models/cpu/iss/isa_gen/isa_rvv.py b/models/cpu/iss/isa_gen/isa_rvv.py
-index 3c39da9e..d213aa35 100644
+index 3c39da9e..83572133 100644
 --- a/models/cpu/iss/isa_gen/isa_rvv.py
 +++ b/models/cpu/iss/isa_gen/isa_rvv.py
-@@ -81,6 +81,8 @@ class Rv32v(IsaSubset):
+@@ -77,10 +77,22 @@ Format_OPVL = [ OutReg     (0, Range(7 , 5)),
+                 InReg      (1, Range(20, 5)),
+ ]
+ 
++# Customized instruction format for index mul and macc
++        # 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
++# OPV   #   func6    |m|   vs2   |   vs1   | rs1 |    vd   |     op      # 
++Format_OPVFX = [ OutVReg     (0, Range(7 , 5)),
++                 InFReg      (0, Range(12, 3)),#rs1
++                 InVReg      (1, Range(15, 5)),#vs1
++                 InVReg      (2, Range(20, 5)),#vs2
++                 UnsignedImm(0, Range(25, 1)),
++]
++
+ class Rv32v(IsaSubset):
  
      def __init__(self):
          super().__init__(name='v', instrs=[
@@ -2525,7 +2678,7 @@ index 3c39da9e..d213aa35 100644
              Instr('vadd.vv'       ,   Format_OPV  ,    '000000 - ----- ----- 000 ----- 1010111'),#inst[25] = VM , VM = 0 mask enable
              Instr('vadd.vi'       ,   Format_OPIVI,    '000000 - ----- ----- 011 ----- 1010111'),
              Instr('vadd.vx'       ,   Format_OPV  ,    '000000 - ----- ----- 100 ----- 1010111'),
-@@ -201,84 +203,92 @@ class Rv32v(IsaSubset):
+@@ -201,84 +213,92 @@ class Rv32v(IsaSubset):
  
  
  
@@ -2536,151 +2689,156 @@ index 3c39da9e..d213aa35 100644
 +
 +            Instr('vfexp.vv'      ,   Format_OPV  ,    '001100 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfexp.vf'      ,   Format_OPVF ,    '001100 - ----- ----- 101 ----- 1010111'),
-+
-+            Instr('vfsub.vv'      ,   Format_OPV  ,    '000010 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfsub.vf'      ,   Format_OPVF ,    '000010 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfsub.vv'      ,   Format_OPV  ,    '000010 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfsub.vf'      ,   Format_OPVF ,    '000010 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfrsub.vf'     ,   Format_OPVF  ,    '100111 - ----- ----- 101 ----- 1010111'),
++            Instr('vfsub.vv'      ,   Format_OPV  ,    '000010 - ----- ----- 001 ----- 1010111'),
++            Instr('vfsub.vf'      ,   Format_OPVF ,    '000010 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfrsub.vf'     ,   Format_OPVF  ,    '100111 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfmin.vv'      ,   Format_OPV  ,    '000100 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfmin.vf'      ,   Format_OPVF ,    '000100 - ----- ----- 101 ----- 1010111'),
++            Instr('vfrsub.vf'     ,   Format_OPVF  ,    '100111 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfmin.vv'      ,   Format_OPV  ,    '000100 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfmin.vf'      ,   Format_OPVF ,    '000100 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfmax.vv'      ,   Format_OPV  ,    '000110 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfmax.vf'      ,   Format_OPVF ,    '000110 - ----- ----- 101 ----- 1010111'),
++            Instr('vfmin.vv'      ,   Format_OPV  ,    '000100 - ----- ----- 001 ----- 1010111'),
++            Instr('vfmin.vf'      ,   Format_OPVF ,    '000100 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfmax.vv'      ,   Format_OPV  ,    '000110 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfmax.vf'      ,   Format_OPVF ,    '000110 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfdiv.vv'      ,   Format_OPV  ,    '100000 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfdiv.vf'      ,   Format_OPVF ,    '100000 - ----- ----- 101 ----- 1010111'),
++            Instr('vfmax.vv'      ,   Format_OPV  ,    '000110 - ----- ----- 001 ----- 1010111'),
++            Instr('vfmax.vf'      ,   Format_OPVF ,    '000110 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfmul.vv'      ,   Format_OPV  ,    '100100 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfmul.vf'      ,   Format_OPVF ,    '100100 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfmul.vv'      ,   Format_OPV  ,    '100100 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfmul.vf'      ,   Format_OPVF ,    '100100 - ----- ----- 101 ----- 1010111'),
++            Instr('vfdiv.vv'      ,   Format_OPV  ,    '100000 - ----- ----- 001 ----- 1010111'),
++            Instr('vfdiv.vf'      ,   Format_OPVF ,    '100000 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfmacc.vv'     ,   Format_OPV  ,    '101100 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfmacc.vf'     ,   Format_OPVF ,    '101100 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfmacc.vv'     ,   Format_OPV  ,    '101100 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfmacc.vf'     ,   Format_OPVF ,    '101100 - ----- ----- 101 ----- 1010111'),
++            Instr('vfmul.vv'      ,   Format_OPV  ,    '100100 - ----- ----- 001 ----- 1010111'),
++            Instr('vfmul.vf'      ,   Format_OPVF ,    '100100 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfnmacc.vv'    ,   Format_OPV  ,    '101101 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfnmacc.vf'    ,   Format_OPVF ,    '101101 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfnmacc.vv'    ,   Format_OPV  ,    '101101 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfnmacc.vf'    ,   Format_OPVF ,    '101101 - ----- ----- 101 ----- 1010111'),
++            Instr('vfmacc.vv'     ,   Format_OPV  ,    '101100 - ----- ----- 001 ----- 1010111'),
++            Instr('vfmacc.vf'     ,   Format_OPVF ,    '101100 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfmsac.vv'     ,   Format_OPV  ,    '101110 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfmsac.vf'     ,   Format_OPVF ,    '101110 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfmsac.vv'     ,   Format_OPV  ,    '101110 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfmsac.vf'     ,   Format_OPVF ,    '101110 - ----- ----- 101 ----- 1010111'),
++            Instr('vfnmacc.vv'    ,   Format_OPV  ,    '101101 - ----- ----- 001 ----- 1010111'),
++            Instr('vfnmacc.vf'    ,   Format_OPVF ,    '101101 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfnmsac.vv'    ,   Format_OPV  ,    '101111 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfnmsac.vf'    ,   Format_OPVF ,    '101111 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfnmsac.vv'    ,   Format_OPV  ,    '101111 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfnmsac.vf'    ,   Format_OPVF ,    '101111 - ----- ----- 101 ----- 1010111'),
++            Instr('vfmsac.vv'     ,   Format_OPV  ,    '101110 - ----- ----- 001 ----- 1010111'),
++            Instr('vfmsac.vf'     ,   Format_OPVF ,    '101110 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfmadd.vv'     ,   Format_OPV  ,    '101000 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfmadd.vf'     ,   Format_OPVF ,    '101000 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfmadd.vv'     ,   Format_OPV  ,    '101000 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfmadd.vf'     ,   Format_OPVF ,    '101000 - ----- ----- 101 ----- 1010111'),
++            Instr('vfnmsac.vv'    ,   Format_OPV  ,    '101111 - ----- ----- 001 ----- 1010111'),
++            Instr('vfnmsac.vf'    ,   Format_OPVF ,    '101111 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfnmadd.vv'    ,   Format_OPV  ,    '101001 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfnmadd.vf'    ,   Format_OPVF ,    '101001 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfnmadd.vv'    ,   Format_OPV  ,    '101001 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfnmadd.vf'    ,   Format_OPVF ,    '101001 - ----- ----- 101 ----- 1010111'),
++            Instr('vfmadd.vv'     ,   Format_OPV  ,    '101000 - ----- ----- 001 ----- 1010111'),
++            Instr('vfmadd.vf'     ,   Format_OPVF ,    '101000 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfmsub.vv'     ,   Format_OPV  ,    '101010 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfmsub.vf'     ,   Format_OPVF ,    '101010 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfmsub.vv'     ,   Format_OPV  ,    '101010 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfmsub.vf'     ,   Format_OPVF ,    '101010 - ----- ----- 101 ----- 1010111'),
++            Instr('vfnmadd.vv'    ,   Format_OPV  ,    '101001 - ----- ----- 001 ----- 1010111'),
++            Instr('vfnmadd.vf'    ,   Format_OPVF ,    '101001 - ----- ----- 101 ----- 1010111'),
  
 -            Instr('vfnmsub.vv'    ,   Format_OPV  ,    '101011 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfnmsub.vf'    ,   Format_OPVF ,    '101011 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
++            Instr('vfmsub.vv'     ,   Format_OPV  ,    '101010 - ----- ----- 001 ----- 1010111'),
++            Instr('vfmsub.vf'     ,   Format_OPVF ,    '101010 - ----- ----- 101 ----- 1010111'),
+ 
+-            Instr('vfredmax.vs'      ,   Format_OPV  ,    '000111 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 +            Instr('vfnmsub.vv'    ,   Format_OPV  ,    '101011 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfnmsub.vf'    ,   Format_OPVF ,    '101011 - ----- ----- 101 ----- 1010111'),
  
--            Instr('vfredmax.vs'      ,   Format_OPV  ,    '000111 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
+-            Instr('vfredmin.vs'      ,   Format_OPV  ,    '000101 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 +            Instr('vfredmax.vs'      ,   Format_OPV  ,    '000111 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfredmax.vx'      ,   Format_OPV  ,    '000111 - ----- ----- 011 ----- 1010111'),
  
--            Instr('vfredmin.vs'      ,   Format_OPV  ,    '000101 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
-+            Instr('vfredmin.vs'      ,   Format_OPV  ,    '000101 - ----- ----- 001 ----- 1010111'),
- 
 -            Instr('vfredsum.vs'      ,   Format_OPV  ,    '000001 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfredosum.vs'     ,   Format_OPV  ,    '000011 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
-+            Instr('vfredsum.vs'      ,   Format_OPV  ,    '000001 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfredsum.vx'      ,   Format_OPV  ,    '000001 - ----- ----- 011 ----- 1010111'),
-+            Instr('vfredosum.vs'     ,   Format_OPV  ,    '000011 - ----- ----- 001 ----- 1010111'),
++            Instr('vfredmin.vs'      ,   Format_OPV  ,    '000101 - ----- ----- 001 ----- 1010111'),
  
 -            Instr('vfwadd.vv'        ,   Format_OPV  ,    '110000 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfwadd.vf'        ,   Format_OPVF ,    '110000 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 -            Instr('vfwadd.wv'        ,   Format_OPV  ,    '110100 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfwadd.wf'        ,   Format_OPVF ,    '110100 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfwadd.vv'        ,   Format_OPV  ,    '110000 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfwadd.vf'        ,   Format_OPVF ,    '110000 - ----- ----- 101 ----- 1010111'),
-+            Instr('vfwadd.wv'        ,   Format_OPV  ,    '110100 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfwadd.wf'        ,   Format_OPVF ,    '110100 - ----- ----- 101 ----- 1010111'),
++            Instr('vfredsum.vs'      ,   Format_OPV  ,    '000001 - ----- ----- 001 ----- 1010111'),
++            Instr('vfredsum.vx'      ,   Format_OPV  ,    '000001 - ----- ----- 011 ----- 1010111'),
++            Instr('vfredosum.vs'     ,   Format_OPV  ,    '000011 - ----- ----- 001 ----- 1010111'),
  
 -            Instr('vfwsub.vv'        ,   Format_OPV  ,    '110010 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfwsub.vf'        ,   Format_OPVF ,    '110010 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 -            Instr('vfwsub.wv'        ,   Format_OPV  ,    '110110 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfwsub.wf'        ,   Format_OPVF ,    '110110 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
++            Instr('vfwadd.vv'        ,   Format_OPV  ,    '110000 - ----- ----- 001 ----- 1010111'),
++            Instr('vfwadd.vf'        ,   Format_OPVF ,    '110000 - ----- ----- 101 ----- 1010111'),
++            Instr('vfwadd.wv'        ,   Format_OPV  ,    '110100 - ----- ----- 001 ----- 1010111'),
++            Instr('vfwadd.wf'        ,   Format_OPVF ,    '110100 - ----- ----- 101 ----- 1010111'),
+ 
+-            Instr('vfwmul.vv'        ,   Format_OPV  ,    '111000 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
+-            Instr('vfwmul.vf'        ,   Format_OPVF ,    '111000 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 +            Instr('vfwsub.vv'        ,   Format_OPV  ,    '110010 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfwsub.vf'        ,   Format_OPVF ,    '110010 - ----- ----- 101 ----- 1010111'),
 +            Instr('vfwsub.wv'        ,   Format_OPV  ,    '110110 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfwsub.wf'        ,   Format_OPVF ,    '110110 - ----- ----- 101 ----- 1010111'),
  
--            Instr('vfwmul.vv'        ,   Format_OPV  ,    '111000 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
--            Instr('vfwmul.vf'        ,   Format_OPVF ,    '111000 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
+-            Instr('vfwmacc.vv'       ,   Format_OPV  ,    '111100 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
+-            Instr('vfwmacc.vf'       ,   Format_OPVF ,    '111100 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 +            Instr('vfwmul.vv'        ,   Format_OPV  ,    '111000 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfwmul.vf'        ,   Format_OPVF ,    '111000 - ----- ----- 101 ----- 1010111'),
  
--            Instr('vfwmacc.vv'       ,   Format_OPV  ,    '111100 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
--            Instr('vfwmacc.vf'       ,   Format_OPVF ,    '111100 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
+-            Instr('vfwmsac.vv'       ,   Format_OPV  ,    '111110 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
+-            Instr('vfwmsac.vf'       ,   Format_OPVF ,    '111110 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 +            Instr('vfwmacc.vv'       ,   Format_OPV  ,    '111100 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfwmacc.vf'       ,   Format_OPVF ,    '111100 - ----- ----- 101 ----- 1010111'),
  
--            Instr('vfwmsac.vv'       ,   Format_OPV  ,    '111110 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
--            Instr('vfwmsac.vf'       ,   Format_OPVF ,    '111110 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
+-            Instr('vfwnmsac.vv'      ,   Format_OPV  ,    '111111 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
+-            Instr('vfwnmsac.vf'      ,   Format_OPVF ,    '111111 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 +            Instr('vfwmsac.vv'       ,   Format_OPV  ,    '111110 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfwmsac.vf'       ,   Format_OPVF ,    '111110 - ----- ----- 101 ----- 1010111'),
  
--            Instr('vfwnmsac.vv'      ,   Format_OPV  ,    '111111 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
--            Instr('vfwnmsac.vf'      ,   Format_OPVF ,    '111111 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
+-            Instr('vfsgnj.vv'        ,   Format_OPV  ,    '001000 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
+-            Instr('vfsgnj.vf'        ,   Format_OPVF ,    '001000 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 +            Instr('vfwnmsac.vv'      ,   Format_OPV  ,    '111111 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfwnmsac.vf'      ,   Format_OPVF ,    '111111 - ----- ----- 101 ----- 1010111'),
  
--            Instr('vfsgnj.vv'        ,   Format_OPV  ,    '001000 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
--            Instr('vfsgnj.vf'        ,   Format_OPVF ,    '001000 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
+-            Instr('vfsgnjn.vv'       ,   Format_OPV  ,    '001001 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
+-            Instr('vfsgnjn.vf'       ,   Format_OPVF ,    '001001 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
 +            Instr('vfsgnj.vv'        ,   Format_OPV  ,    '001000 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfsgnj.vf'        ,   Format_OPVF ,    '001000 - ----- ----- 101 ----- 1010111'),
  
--            Instr('vfsgnjn.vv'       ,   Format_OPV  ,    '001001 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
--            Instr('vfsgnjn.vf'       ,   Format_OPVF ,    '001001 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
-+            Instr('vfsgnjn.vv'       ,   Format_OPV  ,    '001001 - ----- ----- 001 ----- 1010111'),
-+            Instr('vfsgnjn.vf'       ,   Format_OPVF ,    '001001 - ----- ----- 101 ----- 1010111'),
- 
 -            Instr('vfsgnjx.vv'       ,   Format_OPV  ,    '001010 - ----- ----- 001 ----- 1010111', tags=['fp_op']),
 -            Instr('vfsgnjx.vf'       ,   Format_OPVF ,    '001010 - ----- ----- 101 ----- 1010111', tags=['fp_op']),
++            Instr('vfsgnjn.vv'       ,   Format_OPV  ,    '001001 - ----- ----- 001 ----- 1010111'),
++            Instr('vfsgnjn.vf'       ,   Format_OPVF ,    '001001 - ----- ----- 101 ----- 1010111'),
++
 +            Instr('vfsgnjx.vv'       ,   Format_OPV  ,    '001010 - ----- ----- 001 ----- 1010111'),
 +            Instr('vfsgnjx.vf'       ,   Format_OPVF ,    '001010 - ----- ----- 101 ----- 1010111'),
  
              Instr('vfcvt.xu.f.v'     ,   Format_OPV  ,    '010010 - ----- 00000 001 ----- 1010111', tags=['fp_op', 'nseq']),
  
-@@ -374,6 +384,9 @@ class Rv32v(IsaSubset):
+@@ -374,7 +394,13 @@ class Rv32v(IsaSubset):
              Instr('vs2r.v'       ,   Format_OPV  ,    '001 0 001 01000 ----- 000 ----- 0100111'),# vd, (rs1), vm
              Instr('vs4r.v'       ,   Format_OPV  ,    '011 0 001 01000 ----- 000 ----- 0100111'),# vd, (rs1), vm
              Instr('vs8r.v'       ,   Format_OPV  ,    '111 0 001 01000 ----- 000 ----- 0100111'),# vd, (rs1), vm
+-
 +            
 +            # bowwang   
 +            Instr('vid.v'      ,   Format_OPIVI  ,    '010100 - ----- ----- 010 ----- 1010111'),
- 
++            # Custom ISA for index-sparse
++            Instr('vfwxmacc.vf',   Format_OPVFX ,    '110001 - ----- ----- --- ----- 1010110'),
++            Instr('vfwxmul.vf' ,   Format_OPVFX ,    '110011 - ----- ----- --- ----- 1010110'),
++            
              #                           V 1.0
              Instr('vsetvli' ,   Format_OPVLI,    '- ----------- ----- 111 ----- 1010111'), # zimm = {3'b000,vma,vta,vsew[2:0],vlmul[2:0]}
+ 
 diff --git a/models/cpu/iss/src/snitch/decode.cpp b/models/cpu/iss/src/snitch/decode.cpp
 index 6bf10c9b..a6efa5a0 100644
 --- a/models/cpu/iss/src/snitch/decode.cpp

--- a/soft_hier/gvsoc_core.patch
+++ b/soft_hier/gvsoc_core.patch
@@ -166,7 +166,7 @@ index 00000000..fde9d634
 +    return iss_insn_next(iss, insn, pc);
 +}
 diff --git a/models/cpu/iss/include/isa/rv32v.hpp b/models/cpu/iss/include/isa/rv32v.hpp
-index 188f2877..4a1f54ad 100644
+index 188f2877..ac83901e 100644
 --- a/models/cpu/iss/include/isa/rv32v.hpp
 +++ b/models/cpu/iss/include/isa/rv32v.hpp
 @@ -20,8 +20,24 @@
@@ -842,14 +842,34 @@ index 188f2877..4a1f54ad 100644
      return iss_insn_next(iss, insn, pc);
  }
  
-@@ -1005,7 +1284,19 @@ static inline iss_reg_t vfncvt_rtz_x_f_w_exec(Iss *iss, iss_insn_t *insn, iss_re
+@@ -876,6 +1155,9 @@ static inline iss_reg_t vfwmul_vv_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+ }
+ static inline iss_reg_t vfwmul_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+     LIB_CALL4(lib_FWMULVF , REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
++    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +1;
++    uint64_t delay = iss->spatz.timing_insn(insn, 0, REG_OUT(0), REG_IN(1), -1, latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
+     return iss_insn_next(iss, insn, pc);
+ }
+ 
+@@ -885,6 +1167,9 @@ static inline iss_reg_t vfwmacc_vv_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc
+ }
+ static inline iss_reg_t vfwmacc_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+     LIB_CALL4(lib_FWMACCVF , REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
++    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +1;
++    uint64_t delay = iss->spatz.timing_insn(insn, 0, REG_OUT(0), REG_IN(1), -1, latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
+     return iss_insn_next(iss, insn, pc);
+ }
+ 
+@@ -1005,7 +1290,22 @@ static inline iss_reg_t vfncvt_rtz_x_f_w_exec(Iss *iss, iss_insn_t *insn, iss_re
  
  
  
 +// index scalar-vector multiplication
 +static inline iss_reg_t vfwxmul_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
 +    LIB_CALL5(lib_FWXMULVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
-+    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU);
++    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +2;
 +    uint64_t delay = iss->spatz.timing_insn(insn, 0, REG_OUT(0), REG_IN(2), REG_IN(1), latency, iss->top.clock.get_cycles());
 +    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
 +    return iss_insn_next(iss, insn, pc);
@@ -857,6 +877,9 @@ index 188f2877..4a1f54ad 100644
  
 +static inline iss_reg_t vfwxmacc_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
 +    LIB_CALL5(lib_FWXMACCVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
++    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +3;
++    uint64_t delay = iss->spatz.timing_insn(insn, 0, REG_OUT(0), REG_IN(2), REG_IN(1), latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
 +    return iss_insn_next(iss, insn, pc);
 +}
  
@@ -876,7 +899,7 @@ index 84e01c06..cadf5f31 100644
      IssOffloadInsn<iss_reg_t> offload_insn = {
          .opcode=insn->opcode,
 diff --git a/models/cpu/iss/include/isa_lib/vint.h b/models/cpu/iss/include/isa_lib/vint.h
-index 26cb748e..ed727c13 100644
+index 26cb748e..412b5077 100644
 --- a/models/cpu/iss/include/isa_lib/vint.h
 +++ b/models/cpu/iss/include/isa_lib/vint.h
 @@ -31,6 +31,12 @@
@@ -2475,7 +2498,15 @@ index 26cb748e..ed727c13 100644
  
  
  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-@@ -6943,9 +6894,125 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
+@@ -6907,6 +6858,7 @@ static inline iss_reg_t lib_VSETVLI(Iss *iss, int idxRs1, int idxRd, int rs1, is
+         }else{
+             AVL = VL;
+         }
++        // printf("SEW: %d, LMUL: %f, lmul: %d, AVL: %d, VL: %d\n", SEW, LMUL, lmul, AVL, VL);
+     return VL;
+ }
+ 
+@@ -6943,9 +6895,125 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
          }else{
              AVL = VL;
          }

--- a/soft_hier/gvsoc_core.patch
+++ b/soft_hier/gvsoc_core.patch
@@ -166,7 +166,7 @@ index 00000000..fde9d634
 +    return iss_insn_next(iss, insn, pc);
 +}
 diff --git a/models/cpu/iss/include/isa/rv32v.hpp b/models/cpu/iss/include/isa/rv32v.hpp
-index 188f2877..a3db94e3 100644
+index 188f2877..61c7bb2a 100644
 --- a/models/cpu/iss/include/isa/rv32v.hpp
 +++ b/models/cpu/iss/include/isa/rv32v.hpp
 @@ -20,8 +20,24 @@
@@ -479,7 +479,7 @@ index 188f2877..a3db94e3 100644
      return iss_insn_next(iss, insn, pc);
  }
  
-@@ -590,23 +702,35 @@ static inline iss_reg_t vs8r_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+@@ -590,40 +702,68 @@ static inline iss_reg_t vs8r_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
  
  
  static inline iss_reg_t vluxei8_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
@@ -522,7 +522,44 @@ index 188f2877..a3db94e3 100644
      return iss_insn_next(iss, insn, pc);
  }
  
-@@ -689,143 +813,282 @@ static inline iss_reg_t vsse64_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+ static inline iss_reg_t vsuxei8_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+-    LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 8);
++    // LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 8);
++    LIB_CALL4(lib_VSUXEI8V , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0));
++    uint64_t delay = iss->spatz.timing_insn(insn, 2, REG_OUT(0), REG_IN(1), -1, iss->spatz.max_vlsu_latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
++    iss->spatz.max_vlsu_latency = 0;
+     return iss_insn_next(iss, insn, pc);
+ }
+ static inline iss_reg_t vsuxei16_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+-    LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 16);
++    // LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 16);
++    LIB_CALL4(lib_VSUXEI16V , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0));
++    uint64_t delay = iss->spatz.timing_insn(insn, 2, REG_OUT(0), REG_IN(1), -1, iss->spatz.max_vlsu_latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
++    iss->spatz.max_vlsu_latency = 0;
+     return iss_insn_next(iss, insn, pc);
+ }
+ static inline iss_reg_t vsuxei32_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+-    LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 32);
++    // LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 32);
++    LIB_CALL4(lib_VSUXEI32V , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0));
++    uint64_t delay = iss->spatz.timing_insn(insn, 2, REG_OUT(0), REG_IN(1), -1, iss->spatz.max_vlsu_latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
++    iss->spatz.max_vlsu_latency = 0;
+     return iss_insn_next(iss, insn, pc);
+ }
+ static inline iss_reg_t vsuxei64_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
+-    LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 64);
++    // LIB_CALL5(lib_VSUXEIV , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0), 64);
++    LIB_CALL4(lib_VSUXEI64V , REG_GET(0), REG_IN(1), REG_OUT(0), UIM_GET(0));
++    uint64_t delay = iss->spatz.timing_insn(insn, 2, REG_OUT(0), REG_IN(1), -1, iss->spatz.max_vlsu_latency, iss->top.clock.get_cycles());
++    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
++    iss->spatz.max_vlsu_latency = 0;
+     return iss_insn_next(iss, insn, pc);
+ }
+ 
+@@ -689,143 +829,282 @@ static inline iss_reg_t vsse64_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
  
  static inline iss_reg_t vfadd_vv_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
      LIB_CALL4(lib_FADDVV , REG_IN(0), REG_IN(1) , REG_OUT(0), UIM_GET(0));
@@ -819,7 +856,7 @@ index 84e01c06..cadf5f31 100644
      IssOffloadInsn<iss_reg_t> offload_insn = {
          .opcode=insn->opcode,
 diff --git a/models/cpu/iss/include/isa_lib/vint.h b/models/cpu/iss/include/isa_lib/vint.h
-index 26cb748e..5e23b7c5 100644
+index 26cb748e..f89e2b3d 100644
 --- a/models/cpu/iss/include/isa_lib/vint.h
 +++ b/models/cpu/iss/include/isa_lib/vint.h
 @@ -31,6 +31,12 @@
@@ -924,19 +961,19 @@ index 26cb748e..5e23b7c5 100644
  
 +        int32_t val = i;
 +        bool resBin[64];
- 
++
 +        intToBin(SEW, abs(val), resBin);
- 
++
 +        writeToVReg(iss, SEW, vd, i, resBin);
 +
 +    }
 +}
-+
+ 
 +static inline void lib_SLLVV    (Iss *iss, int vs1, int vs2    , int vd, bool vm){
 +    int64_t data1, data2, res;
 +    bool bin[8];
 +    bool resBin[64];
-+
+ 
 +    for (int i = VSTART; i < VL; i++){
 +        if(!(i%8)){
 +            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
@@ -1271,7 +1308,8 @@ index 26cb748e..5e23b7c5 100644
 -    uint8_t data[4];
 -
 -
--
++    uint8_t data[INTF_WIDTH];
+ 
 -    int align = 0;
 -    if(start_add%4 == 1){
 -        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
@@ -1291,8 +1329,7 @@ index 26cb748e..5e23b7c5 100644
 -    }else if(start_add%4 == 3){
 -        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
 -        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
-+    uint8_t data[INTF_WIDTH];
- 
+-
 -        start_add += 1;
 -        align = 1;
 -    }else{
@@ -1601,7 +1638,8 @@ index 26cb748e..5e23b7c5 100644
 -        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
 -        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+2]%2)) ? iss->spatz.vregfile.vregs[vs3][i+2] : 0;
 -        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+3]%2)) ? iss->spatz.vregfile.vregs[vs3][i+3] : 0;
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL; i+=INTF_WIDTH){
+ 
 -        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
@@ -1615,8 +1653,7 @@ index 26cb748e..5e23b7c5 100644
 -        // printf("data3  = %d\n",data[3 ]);
 -
 -        // printf("addr  = %lu\n",start_add);
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL; i+=INTF_WIDTH){
- 
+-
 -        //if(!i){
 -            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
 -        //}else{
@@ -1691,7 +1728,8 @@ index 26cb748e..5e23b7c5 100644
 -        // }else{
 -        //     vlsu.handle_pending_io_access(iss);
 -        // }
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
+ 
 -        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
@@ -1705,8 +1743,7 @@ index 26cb748e..5e23b7c5 100644
 -        // printf("data3  = %d\n",data[3]);
 -
 -        // printf("addr  = %lu\n",start_add);
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
- 
+-
 -        //if(!i){
 -            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
 -        //}else{
@@ -1778,7 +1815,8 @@ index 26cb748e..5e23b7c5 100644
 -        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
 -        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1]/pow(2,8) : 0;
 -        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*4; i+=INTF_WIDTH){
+ 
 -        // if(!i){
 -        //     vlsu.Vlsu_io_access(iss, rs1,vlEN/8,data,true);
 -        // }else{
@@ -1789,8 +1827,7 @@ index 26cb748e..5e23b7c5 100644
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
 -        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*4; i+=INTF_WIDTH){
- 
+-
 -
 -        // printf("STORE32 \n");
 -        // printf("data0  = %d\n",data[0]);
@@ -1897,13 +1934,13 @@ index 26cb748e..5e23b7c5 100644
 -        // }else{
 -        //     vlsu.handle_pending_io_access(iss);
 -        // }
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
- 
+-
 -        data[0]  = iss->spatz.vregfile.vregs[vs3][i+0];
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
 -        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
+ 
 -
 -        // printf("STORE64 \n");
 -        // printf("data0  = %d\n",data[0]);
@@ -1927,7 +1964,7 @@ index 26cb748e..5e23b7c5 100644
      }
  }
  
-@@ -6647,121 +6518,207 @@ static inline void lib_VSSE64V (Iss *iss, iss_reg_t rs1, iss_reg_t rs2, int vd ,
+@@ -6647,229 +6518,309 @@ static inline void lib_VSSE64V (Iss *iss, iss_reg_t rs1, iss_reg_t rs2, int vd ,
  //                                                            INDEXED LOAD/STORE
  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
  
@@ -1941,27 +1978,46 @@ index 26cb748e..5e23b7c5 100644
 -        if(!(i%8)){
 -            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
 -        }
+-
+-        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
+-
+-        if(!(!(vm) && !bin[(i+0)%8])){
+-            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-        }
+-        i++;
 +// Helper function to calculate the correct index value
 +static inline uint64_t bytes_to_uint(const uint8_t *input, uint8_t nbytes) {
 +    uint64_t result = 0;
 +    for (uint8_t i = 0; i < nbytes; i++) {
 +        result |= ((uint64_t)input[i]) << (8 * i);  // Little-endian
-+    }
+     }
 +    return result;
-+}
+ }
  
--        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
--        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
+-static inline void lib_VLUXEI16V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm , float r){
 +// TODO: we assumed INTF_WIDTH >= SEW_BYTES
 +static inline void lib_VLUXEI8V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
 +    /* vm is ignored in this implementation */
-+    uint64_t start_add = rs1;
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
+-    bool bin[8];
+-    uint8_t index;
+-    
+-    int i = VSTART;
 +    uint8_t data[INTF_WIDTH];
 +    uint8_t index[1];
 +    uint8_t sew_bytes = SEW / 8;
  
--        if(!(!(vm) && !bin[(i+0)%8])){
+-    while(i < VL*2){
+-        if(!((i/2)%8)){
+-            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/2)/8],bin);
+-        }
+-        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
+-        if(!(!(vm) && !bin[(i/2+0)%8])){
 -            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
 +    for (int i=0; i < VL; i+=1){
 +        // read index
 +        index[0] = iss->spatz.vregfile.vregs[vs2][i];
@@ -1976,11 +2032,11 @@ index 26cb748e..5e23b7c5 100644
 +        for (int j=0; j<sew_bytes; j++){
 +            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
          }
--        i++;
+-        i+=2;
      }
  }
  
--static inline void lib_VLUXEI16V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm , float r){
+-static inline void lib_VLUXEI32V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
 -    uint64_t start_add = rs1;
 -    uint8_t data[4];
 -    bool bin[8];
@@ -1994,52 +2050,13 @@ index 26cb748e..5e23b7c5 100644
 +    uint8_t index[2];
 +    uint8_t sew_bytes = SEW / 8;
  
--    while(i < VL*2){
--        if(!((i/2)%8)){
--            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/2)/8],bin);
-+    for (int i=0; i < VL; i+=1){
-+        // read index
-+        for (int k=0; k<2; k++){
-+            index[k] = iss->spatz.vregfile.vregs[vs2][i*2+k];
-         }
--        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
--        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
--        if(!(!(vm) && !bin[(i/2+0)%8])){
--            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
--            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
-+        // index load 
-+        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 2));
-+        uint8_t offset = addr % INTF_WIDTH;
-+        iss->spatz.vlsu.Vlsu_io_access(iss, addr-offset, INTF_WIDTH, data, false);
-+        // select bytes for VRF
-+        for (int j=0; j<sew_bytes; j++){
-+            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
-         }
--        i+=2;
-     }
- }
- 
--static inline void lib_VLUXEI32V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
--    uint64_t start_add = rs1;
--    uint8_t data[4];
--    bool bin[8];
--    uint8_t index;
-+static inline void lib_VLUXEI32V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
-     
--    int i = VSTART;
-+    /* vm is ignored in this implementation */
-+    uint64_t start_add = rs1;
-+    uint8_t data[INTF_WIDTH];
-+    uint8_t index[4];
-+    uint8_t sew_bytes = SEW / 8;
- 
 -    while(i < VL*4){
 -        if(!((i/4)%8)){
 -            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/4)/8],bin);
 +    for (int i=0; i < VL; i+=1){
 +        // read index
-+        for (int k=0; k<4; k++){
-+            index[k] = iss->spatz.vregfile.vregs[vs2][i*4+k];
++        for (int k=0; k<2; k++){
++            index[k] = iss->spatz.vregfile.vregs[vs2][i*2+k];
          }
 -    
 -        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
@@ -2052,7 +2069,7 @@ index 26cb748e..5e23b7c5 100644
 -            iss->spatz.vregfile.vregs[vd][i+2] = data[2];
 -            iss->spatz.vregfile.vregs[vd][i+3] = data[3];
 +        // index load 
-+        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 4));
++        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 2));
 +        uint8_t offset = addr % INTF_WIDTH;
 +        iss->spatz.vlsu.Vlsu_io_access(iss, addr-offset, INTF_WIDTH, data, false);
 +        // select bytes for VRF
@@ -2065,7 +2082,7 @@ index 26cb748e..5e23b7c5 100644
  
 -static inline void lib_VLUXEI64V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
 -
-+static inline void lib_VLUXEI64V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
++static inline void lib_VLUXEI32V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
 +    
 +    /* vm is ignored in this implementation */
      uint64_t start_add = rs1;
@@ -2075,7 +2092,7 @@ index 26cb748e..5e23b7c5 100644
 -    int flag = 0;
 -    int i = VSTART;
 +    uint8_t data[INTF_WIDTH];
-+    uint8_t index[8];
++    uint8_t index[4];
 +    uint8_t sew_bytes = SEW / 8;
  
 -    while(i < VL*8){
@@ -2093,8 +2110,8 @@ index 26cb748e..5e23b7c5 100644
 -            iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
 +    for (int i=0; i < VL; i+=1){
 +        // read index
-+        for (int k=0; k<8; k++){
-+            index[k] = iss->spatz.vregfile.vregs[vs2][i*8+k];
++        for (int k=0; k<4; k++){
++            index[k] = iss->spatz.vregfile.vregs[vs2][i*4+k];
          }
 -        if(!(!(vm) && !bin[(i/8+0)%8])){
 -            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
@@ -2102,7 +2119,7 @@ index 26cb748e..5e23b7c5 100644
 -            iss->spatz.vregfile.vregs[vd][i+2] = data[2];
 -            iss->spatz.vregfile.vregs[vd][i+3] = data[3];
 +        // index load 
-+        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 8));
++        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 4));
 +        uint8_t offset = addr % INTF_WIDTH;
 +        iss->spatz.vlsu.Vlsu_io_access(iss, addr-offset, INTF_WIDTH, data, false);
 +        // select bytes for VRF
@@ -2110,9 +2127,9 @@ index 26cb748e..5e23b7c5 100644
 +            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
          }
 -        i+=4;
-     }
- }
- 
+-    }
+-}
+-
 -static inline void lib_VLUXEIV  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, int EEW){
 -    float temp = float(SEW)/float(EEW);
 -    if(SEW == 8){
@@ -2123,107 +2140,322 @@ index 26cb748e..5e23b7c5 100644
 -        lib_VLUXEI32V  (iss, rs1, vs2, vd , vm, temp);
 -    }else if(SEW == 64){
 -        lib_VLUXEI64V  (iss, rs1, vs2, vd , vm, temp);
--    }
--}
-+// static inline void lib_VLUXEI16V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm , float r){
+     }
+ }
+ 
+-
+-static inline void lib_VSUXEI8V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
++static inline void lib_VLUXEI64V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
++    
++    /* vm is ignored in this implementation */
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
+-    bool bin[8];
+-    uint8_t index;
+-    int i = VSTART;
+-    while(i < VL){
+-        if(!(i%8)){
+-            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
+-        }
+-        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-        if(!(!(vm) && !bin[(i+0)%8])){
+-            data[0] = iss->spatz.vregfile.vregs[vd][i+0];
+-            iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),1,data,true);
++    uint8_t data[INTF_WIDTH];
++    uint8_t index[8];
++    uint8_t sew_bytes = SEW / 8;
++
++    for (int i=0; i < VL; i+=1){
++        // read index
++        for (int k=0; k<8; k++){
++            index[k] = iss->spatz.vregfile.vregs[vs2][i*8+k];
++        }
++        // index load 
++        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 8));
++        uint8_t offset = addr % INTF_WIDTH;
++        iss->spatz.vlsu.Vlsu_io_access(iss, addr-offset, INTF_WIDTH, data, false);
++        // select bytes for VRF
++        for (int j=0; j<sew_bytes; j++){
++            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
++        }
++    }
++}
++
++
++// static inline void lib_VSUXEI8V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
++//     uint64_t start_add = rs1;
++//     uint8_t data[INTF_WIDTH];
++//     bool bin[8];
++//     uint8_t index;
++//     int i = VSTART;
++//     while(i < VL){
++//         if(!(i%8)){
++//             intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
++//         }
++//         index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
++//         if(!(!(vm) && !bin[(i+0)%8])){
++//             data[0] = iss->spatz.vregfile.vregs[vd][i+0];
++//             iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),1,data,true);
++//         }
++//         i++;
++//     }
++// }
++
++static inline void lib_VSUXEI8V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
++    /* vm is ignored in this implementation */
++    uint64_t start_add = rs1;
++    uint8_t data[INTF_WIDTH];
++    uint8_t index[1];
++    uint8_t sew_bytes = SEW / 8;
++
++    for (int i=0; i < VL; i+=1){
++        // read index
++        index[0] = iss->spatz.vregfile.vregs[vs2][i];
++        // calculate address
++        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 1));
++        // form data
++        for (int j=0; j<sew_bytes; j++){
++            data[j] = iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j];
+         }
+-        i++;
++        // index store
++        iss->spatz.vlsu.Vlsu_io_access(iss, addr,sew_bytes,data,true);
+     }
+ }
+ 
+-static inline void lib_VSUXEI16V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
++static inline void lib_VSUXEI16V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
++    /* vm is ignored in this implementation */
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
+-    bool bin[8];
+-    uint8_t index;
+-    int i = VSTART;
+-    while(i < VL*2){
+-        if(!((i/2)%8)){
+-            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/2)/8],bin);
++    uint8_t data[INTF_WIDTH];
++    uint8_t index[2];
++    uint8_t sew_bytes = SEW / 8;
++
++    for (int i=0; i < VL; i+=1){
++        // read index
++        for (int k=0; k<2; k++){
++            index[k] = iss->spatz.vregfile.vregs[vs2][i*2+k];
+         }
+-        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-        if(!(!(vm) && !bin[(i/2+0)%8])){
+-            data[0] = iss->spatz.vregfile.vregs[vd][i+0];
+-            data[1] = iss->spatz.vregfile.vregs[vd][i+1];
+-            iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),2,data,true);
++        // calculate address
++        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 2));
++        // form data
++        for (int j=0; j<sew_bytes; j++){
++            data[j] = iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j];
+         }
+-        i+=2;
++        // index store
++        iss->spatz.vlsu.Vlsu_io_access(iss, addr,sew_bytes,data,true);
+     }
+ }
+ 
+-static inline void lib_VSUXEI32V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
++static inline void lib_VSUXEI32V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
++    /* vm is ignored in this implementation */
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
+-    bool bin[8];
+-    uint8_t index;
+-    int i = VSTART;
+-    while(i < VL*4){
+-        if(!((i/4)%8)){
+-            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/4)/8],bin);
++    uint8_t data[INTF_WIDTH];
++    uint8_t index[4];
++    uint8_t sew_bytes = SEW / 8;
++
++    for (int i=0; i < VL; i+=1){
++        // read index
++        for (int k=0; k<4; k++){
++            index[k] = iss->spatz.vregfile.vregs[vs2][i*4+k];
+         }
+-        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-        if(!(!(vm) && !bin[(i/4+0)%8])){
+-            data[0] = iss->spatz.vregfile.vregs[vd][i+0];
+-            data[1] = iss->spatz.vregfile.vregs[vd][i+1];
+-            data[2] = iss->spatz.vregfile.vregs[vd][i+2];
+-            data[3] = iss->spatz.vregfile.vregs[vd][i+3];
+-            iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,true);
++        // calculate address
++        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 4));
++        // form data
++        for (int j=0; j<sew_bytes; j++){
++            data[j] = iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j];
+         }
+-        i+=4;
++        // index store
++        iss->spatz.vlsu.Vlsu_io_access(iss, addr,sew_bytes,data,true);
+     }
+ }
+ 
+-static inline void lib_VSUXEI64V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
++static inline void lib_VSUXEI64V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
++    /* vm is ignored in this implementation */
+     uint64_t start_add = rs1;
+-    uint8_t data[4];
+-    bool bin[8];
+-    uint8_t index;
+-    int i = VSTART;
+-    int flag = 0;
+-    while(i < VL*8){
+-        if(!((i/8)%8)){
+-            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/8)/8],bin);
+-        }
+-
+-        if(!(!(vm) && !bin[(i/8+0)%8])){
+-            data[0] = iss->spatz.vregfile.vregs[vd][i+0];
+-            data[1] = iss->spatz.vregfile.vregs[vd][i+1];
+-            data[2] = iss->spatz.vregfile.vregs[vd][i+2];
+-            data[3] = iss->spatz.vregfile.vregs[vd][i+3];
+-
+-            if(flag){
+-                flag = 0;
+-                iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index+4),4,data,true);
++    uint8_t data[INTF_WIDTH];
++    uint8_t index[8];
++    uint8_t sew_bytes = SEW / 8;
++
++    for (int i=0; i < VL; i+=1){
++        // read index
++        for (int k=0; k<8; k++){
++            index[k] = iss->spatz.vregfile.vregs[vs2][i*8+k];
++        }
++        // calculate address
++        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 8));
++        // form data
++        for (int j=0; j<sew_bytes; j++){
++            data[j] = iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j];
++        }
++        // index store
++        iss->spatz.vlsu.Vlsu_io_access(iss, addr,sew_bytes,data,true);
++    }
++}
++
++// static inline void lib_VSUXEI16V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
 +//     uint64_t start_add = rs1;
 +//     uint8_t data[4];
 +//     bool bin[8];
-+//     uint8_t index; // this is not correct
-+    
++//     uint8_t index;
 +//     int i = VSTART;
-+
 +//     while(i < VL*2){
 +//         if(!((i/2)%8)){
 +//             intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/2)/8],bin);
 +//         }
 +//         index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
-+//         iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
 +//         if(!(!(vm) && !bin[(i/2+0)%8])){
-+//             iss->spatz.vregfile.vregs[vd][i+0] = data[0];
-+//             iss->spatz.vregfile.vregs[vd][i+1] = data[1];
++//             data[0] = iss->spatz.vregfile.vregs[vd][i+0];
++//             data[1] = iss->spatz.vregfile.vregs[vd][i+1];
++//             iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),2,data,true);
 +//         }
 +//         i+=2;
 +//     }
 +// }
 +
-+// static inline void lib_VLUXEI32V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
++// static inline void lib_VSUXEI32V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
 +//     uint64_t start_add = rs1;
 +//     uint8_t data[4];
 +//     bool bin[8];
 +//     uint8_t index;
-+    
 +//     int i = VSTART;
-+
 +//     while(i < VL*4){
 +//         if(!((i/4)%8)){
 +//             intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/4)/8],bin);
 +//         }
-+    
 +//         index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
-+
-+//         iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
-+
 +//         if(!(!(vm) && !bin[(i/4+0)%8])){
-+//             iss->spatz.vregfile.vregs[vd][i+0] = data[0];
-+//             iss->spatz.vregfile.vregs[vd][i+1] = data[1];
-+//             iss->spatz.vregfile.vregs[vd][i+2] = data[2];
-+//             iss->spatz.vregfile.vregs[vd][i+3] = data[3];
++//             data[0] = iss->spatz.vregfile.vregs[vd][i+0];
++//             data[1] = iss->spatz.vregfile.vregs[vd][i+1];
++//             data[2] = iss->spatz.vregfile.vregs[vd][i+2];
++//             data[3] = iss->spatz.vregfile.vregs[vd][i+3];
++//             iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,true);
 +//         }
 +//         i+=4;
 +//     }
 +// }
 +
-+// static inline void lib_VLUXEI64V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
-+
++// static inline void lib_VSUXEI64V (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
 +//     uint64_t start_add = rs1;
 +//     uint8_t data[4];
 +//     bool bin[8];
 +//     uint8_t index;
-+//     int flag = 0;
 +//     int i = VSTART;
-+
++//     int flag = 0;
 +//     while(i < VL*8){
 +//         if(!((i/8)%8)){
 +//             intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/8)/8],bin);
 +//         }
-+    
-+//         if(flag){
-+//             flag = 0;
-+//             iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index+4),4,data,false);
-+    
-+//         }else{
-+//             flag = 1;
-+//             index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
-+//             iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
-+//         }
++
 +//         if(!(!(vm) && !bin[(i/8+0)%8])){
-+//             iss->spatz.vregfile.vregs[vd][i+0] = data[0];
-+//             iss->spatz.vregfile.vregs[vd][i+1] = data[1];
-+//             iss->spatz.vregfile.vregs[vd][i+2] = data[2];
-+//             iss->spatz.vregfile.vregs[vd][i+3] = data[3];
++//             data[0] = iss->spatz.vregfile.vregs[vd][i+0];
++//             data[1] = iss->spatz.vregfile.vregs[vd][i+1];
++//             data[2] = iss->spatz.vregfile.vregs[vd][i+2];
++//             data[3] = iss->spatz.vregfile.vregs[vd][i+3];
++
++//             if(flag){
++//                 flag = 0;
++//                 iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index+4),4,data,true);
+         
+-            }else{
+-                flag = 1;
+-                index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-                iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,true);
+-            }
+-        }
+-        i+=4;
+-    }
+-}
+-
+-static inline void lib_VSUXEIV  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, int EEW){
+-    float temp = float(SEW)/float(EEW);
+-
+-    if(SEW == 8){
+-        lib_VSUXEI8V   (iss, rs1, vs2, vd , vm, temp);
+-    }else if(SEW == 16){
+-        lib_VSUXEI16V  (iss, rs1, vs2, vd , vm, temp);
+-    }else if(SEW == 32){
+-        lib_VSUXEI32V  (iss, rs1, vs2, vd , vm, temp);
+-    }else if(SEW == 64){
+-        lib_VSUXEI64V  (iss, rs1, vs2, vd , vm, temp);
+-    }
+-}
++//             }else{
++//                 flag = 1;
++//                 index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
++//                 iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,true);
++//             }
 +//         }
 +//         i+=4;
 +//     }
 +// }
 +
-+// bowwang: this is not correct
-+// static inline void lib_VLUXEIV  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, int EEW){
++// static inline void lib_VSUXEIV  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, int EEW){
 +//     float temp = float(SEW)/float(EEW);
++
 +//     if(SEW == 8){
-+//         lib_VLUXEI8V   (iss, rs1, vs2, vd , vm, temp);
++//         // lib_VSUXEI8V   (iss, rs1, vs2, vd , vm, temp);
 +//     }else if(SEW == 16){
-+//         lib_VLUXEI16V  (iss, rs1, vs2, vd , vm, temp);
++//         lib_VSUXEI16V  (iss, rs1, vs2, vd , vm, temp);
 +//     }else if(SEW == 32){
-+//         lib_VLUXEI32V  (iss, rs1, vs2, vd , vm, temp);
++//         lib_VSUXEI32V  (iss, rs1, vs2, vd , vm, temp);
 +//     }else if(SEW == 64){
-+//         lib_VLUXEI64V  (iss, rs1, vs2, vd , vm, temp);
++//         lib_VSUXEI64V  (iss, rs1, vs2, vd , vm, temp);
 +//     }
 +// }
  
  
- static inline void lib_VSUXEI8V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
-@@ -6943,6 +6900,7 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
+ /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+@@ -6943,6 +6894,7 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
          }else{
              AVL = VL;
          }


### PR DESCRIPTION
# Add FP8 Widening and AspB MatMul Kernels with Supporting Infrastructure

This PR introduces new FP8 widening support, AspB MatMul kernel implementations, and corresponding test and utility enhancements. 

---

##  Software and Kernel Enhancements

- Added **FP8 widening MatMul baseline kernel** for performance and correctness validation.
- Implemented **AspB MatMul application**, including:
  - Support for **compact index matrices**
  - A kernel variant using **`vfmx_.vf` instructions**

---

##  Spatz Instruction Extensions

- Implemented **FP8 widening indexed instructions** (`vfwx_.vf`)
- Added **index store instruction** support
- Integrated **timing models** for `vfwx_.vf` into the Spatz backend

---

## Instruction and Kernel Testing

- Added unit tests for:
  - **FP8 widening instructions**
  - `vsuxei8.v`, `vsuxei.v`
  - `vfwx_.vf`
- Extended test coverage for newly supported instructions and MatMul variants

---

## Utilities and Data Generation

- Wrapped common **FP8 data generation functions** into a reusable library
- Added support for:
  - **NM-format** data generation
  - **`AspB_matmul`** specific data generator script
  - **Compact index matrix generation**

---

## Miscellaneous Improvements

- Exposed **mismatch tolerance** configuration for test flexibility
- Updated the **AspB README** with new usage instructions


