### PR TITLE
Rebase sp opt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,6 @@ pfto_spatz:
 		--binary sw_build/softhier.elf run $(preload_arg) \
 		--trace-level=trace \
 		--trace="/chip/cluster_0/*" \
-		--trace="icache" \
 		| tee $(trace_file); \
 	if [ -n "$(trace_name)" ]; then \
 		out_name=$(trace_name)_trace; \
@@ -244,3 +243,6 @@ pfto_spatz:
 	python soft_hier/flex_cluster_utilities/trace_perfetto/parse.py $(trace_file) sw_build/roi.json; \
 	python soft_hier/flex_cluster_utilities/trace_perfetto/visualize.py sw_build/roi.json -o ./$$out_name.json; \
 	echo "Generated ./$$out_name.json"
+
+clean_trace:
+	rm *_trace.json

--- a/examples/SoftHier/assembled/Spatz_GEMM/README.md
+++ b/examples/SoftHier/assembled/Spatz_GEMM/README.md
@@ -10,6 +10,30 @@ cfg={SOFTHIER_ROOT}/examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py 
 
 ## Updates
 
+### Add auto-benchmark script `spatz_auto_benchmark.sh`
+Simply use the following command with marked steps to run multiple benchmarks:
+1. Set `P` dimension in the script
+2. set the data format config (`--sparse`, `--idx_compact`) in the script
+3. Set kernel to benchmark in `main.c`
+4. Run the following command
+```tcl
+./examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_auto_benchmark.sh > benchmark_output.txt
+```
+
+### Add optimized sparse kernels
+All the following kernels have been tested with 2:4 format:
+**Dense**
+- `spatz_matmul_fp16()`: baseline
+- `spatz_matmul_unroll2_fp16()`: 2x-unroll on N-dimension
+- `spatz_matmul_unroll4_fp16()`: 4x-unroll on N-dimension
+**Software-emulation**
+- `spatz_AspB_matmul_fp16()`: baseline
+**Custom RVV: widening-indexed(vfwx_.vf)**
+- `spatz_AspB_matmul_wxfp16()`: baseline
+- `spatz_AspB_matmul_unroll4_wxfp16()`: 4x-unroll on N-dimension
+- `spatz_AspB_matmul_unroll2x2_wxfp16()`: 2x-unroll on N-dimension, 2x-unroll on M-dimension
+- `spatz_AspB_matmul_unroll4x2_wxfp16()`: 4x-unroll on N-dimension, 2x-unroll on M-dimension
+
 ### Merged dense/sparse data generation script
 How to use:
 ```tcl

--- a/examples/SoftHier/assembled/Spatz_GEMM/README.md
+++ b/examples/SoftHier/assembled/Spatz_GEMM/README.md
@@ -22,12 +22,15 @@ Simply use the following command with marked steps to run multiple benchmarks:
 
 ### Add optimized sparse kernels
 All the following kernels have been tested with 2:4 format:
+
 **Dense**
 - `spatz_matmul_fp16()`: baseline
 - `spatz_matmul_unroll2_fp16()`: 2x-unroll on N-dimension
 - `spatz_matmul_unroll4_fp16()`: 4x-unroll on N-dimension
+
 **Software-emulation**
 - `spatz_AspB_matmul_fp16()`: baseline
+
 **Custom RVV: widening-indexed(vfwx_.vf)**
 - `spatz_AspB_matmul_wxfp16()`: baseline
 - `spatz_AspB_matmul_unroll4_wxfp16()`: 4x-unroll on N-dimension

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
@@ -188,13 +188,18 @@ void spatz_AspB_matmul_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* ma
                 asm volatile("flw ft0, (%0)" :: "r"(p_a));
 
                 // load b vec
-                uint8_t *p_b = &matrix_b[p + n*P*spN/spM];
+                // TODO: adapt to other NM formats
+                // uint8_t *p_b = &matrix_b[p + n*P*spN/spM];
+                uint8_t *p_b = &matrix_b[p + n*P/2];
+
                 asm volatile("vle8.v v0, (%0)" ::"r"(p_b));
 
                 // load index 
-                uint8_t *p_index = &index_b[(p + n*P*spN/spM)/IDX_PER_BYTE];
+                // TODO: adapt to other formats
+                // uint8_t *p_index = &index_b[(p + n*P*spN/spM)/IDX_PER_BYTE];
+                uint8_t *p_index = &index_b[(p + n*P/2)/IDX_PER_BYTE];
                 asm volatile("vle8.v v8, (%0)" ::"r"(p_index));
-                // flex_timer_start();
+
                 if (n==0){ // first iter
                     // reset registers
                     asm volatile("vsetvli %0, %1, e16, m8, ta, ma" : "=r"(vl_dump) : "r"(2*avl));
@@ -226,6 +231,546 @@ void spatz_AspB_matmul_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* ma
             asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
             asm volatile("vse16.v v16, (%0)" ::"r"(p_c));
             asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(avl));
+        }
+        avl -= vl;
+        p += vl;
+    } while (avl>0);
+}
+
+// Unroll-optimized kernels
+// 2x-unrolled dense matmul [Gustav], input _fp8, output _fp16
+void spatz_matmul_unroll2_fp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, 
+                  const uint32_t M, const uint32_t N, const uint32_t P){
+
+    // init counters
+    uint32_t p = 0;
+
+    uint32_t avl = P;
+    uint32_t vl;
+    do{
+        asm volatile("vsetvli %0, %1, e8, m4, ta, ma" : "=r"(vl) : "r"(avl));
+        for (uint32_t m = 0; m < M; m+=2){
+            uint16_t *p_c = matrix_c + m*P + p;
+            uint16_t *p_c2 = matrix_c + m*P + p + P;
+            for (uint32_t n = 0; n < N; n++){
+                // load a
+                uint8_t *p_a  = &matrix_a[m*N + n];
+                uint8_t *p_a2 = &matrix_a[m*N + n + N];
+                asm volatile("flw fa0, (%0)" :: "r"(p_a));
+                asm volatile("flw fa1, (%0)" :: "r"(p_a2));
+
+                // load b vec
+                uint8_t *p_b = &matrix_b[p + n*P];
+
+                asm volatile("vle8.v v0, (%0)" ::"r"(p_b));
+                if (n==0){ // first iter
+                    asm volatile("vmv.v.i v16, 0");
+                    asm volatile("vmv.v.i v20, 0");
+                    asm volatile("vfwmul.vf v16, v0, fa0");
+                    asm volatile("vfwmul.vf v20, v0, fa1");
+                } else {
+                    asm volatile("vfwmacc.vf v16, fa0, v0");
+                    asm volatile("vfwmacc.vf v20, fa1, v0");
+                }
+            }
+            asm volatile("vse16.v v16, (%0)" ::"r"(p_c));
+            asm volatile("vse16.v v20, (%0)" ::"r"(p_c2));
+        }
+        avl -= vl;
+        p += vl;
+    } while (avl>0);
+}
+
+// 4x-unrolled dense matmul [Gustav], input _fp8, output _fp16
+void spatz_matmul_unroll4_fp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, 
+                  const uint32_t M, const uint32_t N, const uint32_t P){
+
+    // init counters
+    uint32_t p = 0;
+
+    uint32_t avl = P;
+    uint32_t vl;
+    do{
+        asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        for (uint32_t m = 0; m < M; m+=4){
+            uint16_t *p_c  = matrix_c + m*P + p;
+            uint16_t *p_c2 = matrix_c + m*P + p + P;
+            uint16_t *p_c3 = matrix_c + m*P + p + 2*P;
+            uint16_t *p_c4 = matrix_c + m*P + p + 3*P;
+            for (uint32_t n = 0; n < N; n++){
+                // load a
+                uint8_t *p_a  = &matrix_a[m*N + n];
+                uint8_t *p_a2 = &matrix_a[m*N + n + N];
+                uint8_t *p_a3 = &matrix_a[m*N + n + 2*N];
+                uint8_t *p_a4 = &matrix_a[m*N + n + 3*N];
+                asm volatile("flw fa0, (%0)" :: "r"(p_a));
+                asm volatile("flw fa1, (%0)" :: "r"(p_a2));
+                asm volatile("flw fa2, (%0)" :: "r"(p_a3));
+                asm volatile("flw fa3, (%0)" :: "r"(p_a4));
+
+                // load b vec
+                uint8_t *p_b = &matrix_b[p + n*P];
+
+                asm volatile("vle8.v v0, (%0)" ::"r"(p_b));
+                if (n==0){ // first iter
+                    asm volatile("vmv.v.i v8, 0");
+                    asm volatile("vmv.v.i v12, 0");
+                    asm volatile("vmv.v.i v16, 0");
+                    asm volatile("vmv.v.i v20, 0");
+                    asm volatile("vfwmul.vf v8, v0, fa0");
+                    asm volatile("vfwmul.vf v12, v0, fa1");
+                    asm volatile("vfwmul.vf v16, v0, fa2");
+                    asm volatile("vfwmul.vf v20, v0, fa3");
+                } else {
+                    asm volatile("vfwmacc.vf v8, fa0, v0");
+                    asm volatile("vfwmacc.vf v12, fa1, v0");
+                    asm volatile("vfwmacc.vf v16, fa2, v0");
+                    asm volatile("vfwmacc.vf v20, fa3, v0");
+                }
+            }
+            asm volatile("vse16.v v8,  (%0)" ::"r"(p_c));
+            asm volatile("vse16.v v12, (%0)" ::"r"(p_c2));
+            asm volatile("vse16.v v16, (%0)" ::"r"(p_c3));
+            asm volatile("vse16.v v20, (%0)" ::"r"(p_c4));
+        }
+        avl -= vl;
+        p += vl;
+    } while (avl>0);
+}
+
+
+void spatz_AspB_matmul_unroll4_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, uint8_t* index_b,
+                  const uint32_t M, const uint32_t N, const uint32_t P, 
+                  const uint8_t spN, const uint8_t spM){
+
+    // init counters
+    uint32_t p = 0;
+
+    uint32_t avl = P * spN / spM;
+    uint32_t vl, vl_dump;
+
+    do{ // outer loop 
+        asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        for (uint32_t m = 0; m < M; m+=4){ // mid loop
+            uint16_t *p_c  = matrix_c + m*P + p;
+            uint16_t *p_c2 = p_c + P;
+            uint16_t *p_c3 = p_c + 2*P;
+            uint16_t *p_c4 = p_c + 3*P;
+            for (uint32_t n = 0; n < N; n++){
+                // load a
+                uint8_t *p_a  = &matrix_a[m*N + n];
+                uint8_t *p_a2 = p_a + N;
+                uint8_t *p_a3 = p_a + 2*N;
+                uint8_t *p_a4 = p_a + 3*N;
+                asm volatile("flw ft0, (%0)" :: "r"(p_a));
+                asm volatile("flw ft1, (%0)" :: "r"(p_a2));
+                asm volatile("flw ft2, (%0)" :: "r"(p_a3));
+                asm volatile("flw ft3, (%0)" :: "r"(p_a4));
+
+
+                // load b vec
+                // TODO: adapt to other formats
+                // uint8_t *p_b = &matrix_b[p + n*P*spN/spM];
+                
+                uint8_t *p_b = &matrix_b[p + n*P/2];
+                asm volatile("vle8.v v0, (%0)" ::"r"(p_b));
+
+                // load index 
+                // uint8_t *p_index = &index_b[(p + n*P*spN/spM)/IDX_PER_BYTE];
+                uint8_t *p_index = &index_b[(p + n*P/2)/IDX_PER_BYTE];
+                asm volatile("vle8.v v4, (%0)" ::"r"(p_index));
+
+                if (n==0){ // first iter
+                    // reset registers
+                    asm volatile("vsetvli %0, %1, e16, m2, ta, ma" : "=r"(vl_dump) : "r"(2*avl));
+                    asm volatile("vmv.v.i v8, 0");
+                    asm volatile("vmv.v.i v12, 0");
+                    asm volatile("vmv.v.i v16, 0");
+                    asm volatile("vmv.v.i v20, 0");
+                    asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+                    // vfwxmul.vf _inp, _idx, _fp, _oup
+                    // v8 <-- ft0, v4, v0
+                    asm volatile(
+                        ".word  (0b110011  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b000     << 12) | \
+                                (0b01000   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                    // v12 <-- ft1, v4, v0
+                    asm volatile(
+                        ".word  (0b110011  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b001     << 12) | \
+                                (0b01100   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                    // v16 <-- ft2, v4, v0
+                    asm volatile(
+                        ".word  (0b110011  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b010     << 12) | \
+                                (0b10000   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                    // v20 <-- ft3, v4, v0
+                    asm volatile(
+                        ".word  (0b110011  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b011     << 12) | \
+                                (0b10100   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                    
+                } else {
+                    // vfwxmacc.vf _inp, _idx, _fp, _oup
+                    asm volatile(
+                        ".word  (0b110001  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b000     << 12) | \
+                                (0b01000   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                    asm volatile(
+                        ".word  (0b110001  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b001     << 12) | \
+                                (0b01100   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                    asm volatile(
+                        ".word  (0b110001  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b010     << 12) | \
+                                (0b10000   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                    asm volatile(
+                        ".word  (0b110001  << 26) | \
+                                (0b1       << 25) | \
+                                (0b00000   << 20) | \
+                                (0b00100   << 15) | \
+                                (0b011     << 12) | \
+                                (0b10100   <<  7) | \
+                                (0b1010110 <<  0)   \n");
+                }
+                // flex_timer_end();
+            }
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
+            asm volatile("vse16.v v8, (%0)" ::"r"(p_c));
+            asm volatile("vse16.v v12, (%0)" ::"r"(p_c2));
+            asm volatile("vse16.v v16, (%0)" ::"r"(p_c3));
+            asm volatile("vse16.v v20, (%0)" ::"r"(p_c4));
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        }
+        avl -= vl;
+        p += vl;
+    } while (avl>0);
+}
+
+void spatz_AspB_matmul_unroll2x2_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, uint8_t* index_b,
+                  const uint32_t M, const uint32_t N, const uint32_t P, 
+                  const uint8_t spN, const uint8_t spM){
+
+    // init counters
+    uint32_t p = 0;
+
+    uint32_t avl = P * spN / spM;
+    uint32_t vl, vl_dump;
+
+    do{ // outer loop 
+        asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        for (uint32_t m = 0; m < M; m+=2){ // mid loop
+            uint16_t *p_c  = matrix_c + m*P + p;
+            uint16_t *p_c2 = p_c + P;
+
+            // load A: first column
+            uint8_t *p_a00  = &matrix_a[m*N];
+            uint8_t *p_a10 = p_a00 + N;
+            asm volatile("flw ft0, (%0)" :: "r"(p_a00));
+            asm volatile("flw ft1, (%0)" :: "r"(p_a10));
+            // load A: preload second column
+            uint8_t *p_a01  = &matrix_a[m*N + 1];
+            uint8_t *p_a11 = p_a01 + N;
+            asm volatile("flw ft2, (%0)" :: "r"(p_a01));
+            asm volatile("flw ft3, (%0)" :: "r"(p_a11));
+
+            // load B: first row
+            uint8_t *p_b0 = &matrix_b[p];
+            asm volatile("vle8.v v0, (%0)" ::"r"(p_b0));
+            // load Index: first row
+            uint8_t *p_index0 = &index_b[p/IDX_PER_BYTE];
+            asm volatile("vle8.v v4, (%0)" ::"r"(p_index0));
+
+            // load B: preload second row
+            uint8_t *p_b1 = &matrix_b[p + P/2];
+            asm volatile("vle8.v v2, (%0)" ::"r"(p_b1));
+            // load index: preload second row
+            uint8_t *p_index1 = &index_b[(p + P/2)/IDX_PER_BYTE];
+            asm volatile("vle8.v v6, (%0)" ::"r"(p_index1));
+
+            // reset registers
+            asm volatile("vsetvli %0, %1, e16, m2, ta, ma" : "=r"(vl_dump) : "r"(2*avl));
+            asm volatile("vmv.v.i v8, 0");
+            asm volatile("vmv.v.i v12, 0");
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+
+            for (uint32_t n = 0; n < N; n+=2){
+                // first iteration: vfwxmacc.vf _inp, _idx, _fp, _oup
+                // v8 <-- ft0, v4, v0
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00000   << 20) | \
+                            (0b00100   << 15) | \
+                            (0b000     << 12) | \
+                            (0b01000   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v12 <-- ft1, v4, v0
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00000   << 20) | \
+                            (0b00100   << 15) | \
+                            (0b001     << 12) | \
+                            (0b01100   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+
+                // preload A: first set
+                p_a00  = &matrix_a[m*N + n + 2];
+                p_a10 = p_a00 + N;
+                asm volatile("flw ft0, (%0)" :: "r"(p_a00));
+                asm volatile("flw ft1, (%0)" :: "r"(p_a10));
+                // preload B: first set
+                p_b0 = &matrix_b[p + (n+2)*P/2];
+                asm volatile("vle8.v v0, (%0)" ::"r"(p_b0));
+                // preload index: first set
+                p_index0 = &index_b[(p + (n+2)*P/2)/IDX_PER_BYTE];
+                asm volatile("vle8.v v4, (%0)" ::"r"(p_index0));
+
+                // second iteration: vfwxmacc.vf _inp, _idx, _fp, _oup
+                // v8 <-- ft2, v6, v2
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00010   << 20) | \
+                            (0b00110   << 15) | \
+                            (0b010     << 12) | \
+                            (0b01000   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v12 <-- ft3, v6, v2
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00010   << 20) | \
+                            (0b00110   << 15) | \
+                            (0b011     << 12) | \
+                            (0b01100   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+
+                // preload A: second set
+                p_a01  = &matrix_a[m*N + n + 3];
+                p_a11 = p_a01 + N;
+                asm volatile("flw ft2, (%0)" :: "r"(p_a01));
+                asm volatile("flw ft3, (%0)" :: "r"(p_a11));
+                // preload B: second set
+                p_b1 = &matrix_b[p + (n+3)*P/2];
+                asm volatile("vle8.v v2, (%0)" ::"r"(p_b1));
+                // preload index: second set
+                p_index1 = &index_b[(p + (n+3)*P/2)/IDX_PER_BYTE];
+                asm volatile("vle8.v v6, (%0)" ::"r"(p_index1));
+            }
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
+            asm volatile("vse16.v v8, (%0)" ::"r"(p_c));
+            asm volatile("vse16.v v12, (%0)" ::"r"(p_c2));
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        }
+        avl -= vl;
+        p += vl;
+    } while (avl>0);
+}
+
+void spatz_AspB_matmul_unroll4x2_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, uint16_t* matrix_c, uint8_t* index_b,
+                  const uint32_t M, const uint32_t N, const uint32_t P, 
+                  const uint8_t spN, const uint8_t spM){
+
+    // init counters
+    uint32_t p = 0;
+
+    uint32_t avl = P * spN / spM;
+    uint32_t vl, vl_dump;
+
+    do{ // outer loop 
+        asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+        for (uint32_t m = 0; m < M; m+=4){ // mid loop
+            uint16_t *p_c  = matrix_c + m*P + p;
+            uint16_t *p_c2 = p_c + P;
+            uint16_t *p_c3 = p_c + 2*P;
+            uint16_t *p_c4 = p_c + 3*P;
+
+            // load A: first column
+            uint8_t *p_a00  = &matrix_a[m*N];
+            uint8_t *p_a10 = p_a00 + N;
+            uint8_t *p_a20 = p_a00 + 2*N;
+            uint8_t *p_a30 = p_a00 + 3*N;
+            asm volatile("flw ft0, (%0)" :: "r"(p_a00));
+            asm volatile("flw ft1, (%0)" :: "r"(p_a10));
+            asm volatile("flw ft4, (%0)" :: "r"(p_a20));
+            asm volatile("flw ft5, (%0)" :: "r"(p_a30));
+            // load A: preload second column
+            uint8_t *p_a01  = &matrix_a[m*N + 1];
+            uint8_t *p_a11 = p_a01 + N;
+            uint8_t *p_a21 = p_a01 + 2*N;
+            uint8_t *p_a31 = p_a01 + 3*N;
+            asm volatile("flw ft2, (%0)" :: "r"(p_a01));
+            asm volatile("flw ft3, (%0)" :: "r"(p_a11));
+            asm volatile("flw ft6, (%0)" :: "r"(p_a21));
+            asm volatile("flw ft7, (%0)" :: "r"(p_a31));
+
+            // load B: first row
+            uint8_t *p_b0 = &matrix_b[p];
+            asm volatile("vle8.v v0, (%0)" ::"r"(p_b0));
+            // load Index: first row
+            uint8_t *p_index0 = &index_b[p/IDX_PER_BYTE];
+            asm volatile("vle8.v v4, (%0)" ::"r"(p_index0));
+
+            // load B: preload second row
+            uint8_t *p_b1 = &matrix_b[p + P/2];
+            asm volatile("vle8.v v2, (%0)" ::"r"(p_b1));
+            // load index: preload second row
+            uint8_t *p_index1 = &index_b[(p + P/2)/IDX_PER_BYTE];
+            asm volatile("vle8.v v6, (%0)" ::"r"(p_index1));
+
+            // reset registers
+            asm volatile("vsetvli %0, %1, e16, m2, ta, ma" : "=r"(vl_dump) : "r"(2*avl));
+            asm volatile("vmv.v.i v8, 0");
+            asm volatile("vmv.v.i v12, 0");
+            asm volatile("vmv.v.i v16, 0");
+            asm volatile("vmv.v.i v20, 0");
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
+
+            for (uint32_t n = 0; n < N; n+=2){
+                // first iteration: vfwxmacc.vf _inp, _idx, _fp, _oup
+                // v8 <-- ft0, v4, v0
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00000   << 20) | \
+                            (0b00100   << 15) | \
+                            (0b000     << 12) | \
+                            (0b01000   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v12 <-- ft1, v4, v0
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00000   << 20) | \
+                            (0b00100   << 15) | \
+                            (0b001     << 12) | \
+                            (0b01100   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v16 <-- ft4, v4, v0
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00000   << 20) | \
+                            (0b00100   << 15) | \
+                            (0b100     << 12) | \
+                            (0b10000   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v20 <-- ft5, v4, v0
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00000   << 20) | \
+                            (0b00100   << 15) | \
+                            (0b101     << 12) | \
+                            (0b10100   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+
+                // preload A: first set
+                p_a00  = &matrix_a[m*N + n + 2];
+                p_a10 = p_a00 + N;
+                p_a20 = p_a00 + 2*N;
+                p_a30 = p_a00 + 3*N;
+                asm volatile("flw ft0, (%0)" :: "r"(p_a00));
+                asm volatile("flw ft1, (%0)" :: "r"(p_a10));
+                asm volatile("flw ft4, (%0)" :: "r"(p_a20));
+                asm volatile("flw ft5, (%0)" :: "r"(p_a30));
+                // preload B: first set
+                p_b0 = &matrix_b[p + (n+2)*P/2];
+                asm volatile("vle8.v v0, (%0)" ::"r"(p_b0));
+                // preload index: first set
+                p_index0 = &index_b[(p + (n+2)*P/2)/IDX_PER_BYTE];
+                asm volatile("vle8.v v4, (%0)" ::"r"(p_index0));
+
+                // second iteration: vfwxmacc.vf _inp, _idx, _fp, _oup
+                // v8 <-- ft2, v6, v2
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00010   << 20) | \
+                            (0b00110   << 15) | \
+                            (0b010     << 12) | \
+                            (0b01000   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v12 <-- ft3, v6, v2
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00010   << 20) | \
+                            (0b00110   << 15) | \
+                            (0b011     << 12) | \
+                            (0b01100   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v16 <-- ft6, v6, v2
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00010   << 20) | \
+                            (0b00110   << 15) | \
+                            (0b110     << 12) | \
+                            (0b10000   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+                // v20 <-- ft7, v6, v2
+                asm volatile(
+                    ".word  (0b110001  << 26) | \
+                            (0b1       << 25) | \
+                            (0b00010   << 20) | \
+                            (0b00110   << 15) | \
+                            (0b111     << 12) | \
+                            (0b10100   <<  7) | \
+                            (0b1010110 <<  0)   \n");
+
+                // preload A: second set
+                p_a01  = &matrix_a[m*N + n + 3];
+                p_a11 = p_a01 + N;
+                p_a21 = p_a01 + 2*N;
+                p_a31 = p_a01 + 3*N;
+                asm volatile("flw ft2, (%0)" :: "r"(p_a01));
+                asm volatile("flw ft3, (%0)" :: "r"(p_a11));
+                asm volatile("flw ft6, (%0)" :: "r"(p_a21));
+                asm volatile("flw ft7, (%0)" :: "r"(p_a31));
+                // preload B: second set
+                p_b1 = &matrix_b[p + (n+3)*P/2];
+                asm volatile("vle8.v v2, (%0)" ::"r"(p_b1));
+                // preload index: second set
+                p_index1 = &index_b[(p + (n+3)*P/2)/IDX_PER_BYTE];
+                asm volatile("vle8.v v6, (%0)" ::"r"(p_index1));
+            }
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl_dump) : "r"(avl*2));
+            asm volatile("vse16.v v8, (%0)" ::"r"(p_c));
+            asm volatile("vse16.v v12, (%0)" ::"r"(p_c2));
+            asm volatile("vse16.v v16, (%0)" ::"r"(p_c3));
+            asm volatile("vse16.v v20, (%0)" ::"r"(p_c4));
+            asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
         }
         avl -= vl;
         p += vl;

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
@@ -98,11 +98,16 @@ int main()
         #elif _OUT_TYPE == 2
 
         #ifndef __SPARSE__
-        spatz_matmul_fp16(matrix_a, matrix_b, matrix_c, FP8_M, FP8_N, FP8_P);
+        // spatz_matmul_fp16(matrix_a, matrix_b, matrix_c, FP8_M, FP8_N, FP8_P);
+        // spatz_matmul_unroll2_fp16(matrix_a, matrix_b, matrix_c, FP8_M, FP8_N, FP8_P);
+        spatz_matmul_unroll4_fp16(matrix_a, matrix_b, matrix_c, FP8_M, FP8_N, FP8_P);
         #else
 
         #if _IDX_TYPE == _IDX_COMPACT
-        spatz_AspB_matmul_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
+        // spatz_AspB_matmul_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
+        // spatz_AspB_matmul_unroll4_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
+        // spatz_AspB_matmul_unroll2x2_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
+        spatz_AspB_matmul_unroll4x2_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
         #else
         spatz_AspB_matmul_fp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
         #endif
@@ -110,7 +115,7 @@ int main()
         flex_timer_end();
 
         // verify
-        spatz_verify_16(FP8_M * FP8_P, matrix_c, matrix_c_fp16, 0.25f);
+        // spatz_verify_16(FP8_M * FP8_P, matrix_c, matrix_c_fp16, 0.25f);
         #endif // _OUT_TYPT compute
     }
 

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
@@ -115,7 +115,7 @@ int main()
         flex_timer_end();
 
         // verify
-        // spatz_verify_16(FP8_M * FP8_P, matrix_c, matrix_c_fp16, 0.25f);
+        spatz_verify_16(FP8_M * FP8_P, matrix_c, matrix_c_fp16, 0.25f);
         #endif // _OUT_TYPT compute
     }
 

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_auto_benchmark.sh
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_auto_benchmark.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# List of P values to test
+P_VALUES=(32 128 512 1024)
+
+for P in "${P_VALUES[@]}"; do
+  echo "Running with P=$P"
+
+  # Run data generation script
+  python examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_matmul_datagen.py \
+    -M 32 -N 32 -P $P -spN 2 -spM 4 --sparse --idx_compact
+
+  # Run make commands
+  cfg=examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py \
+  app=examples/SoftHier/assembled/Spatz_GEMM/software \
+  make hs; make run
+done

--- a/soft_hier/gvsoc_core.patch
+++ b/soft_hier/gvsoc_core.patch
@@ -96,6 +96,35 @@ index 354a1e51..c640eeb8 100644
  #include "cpu/iss/include/isa/rv32frep.hpp"
  #include "cpu/iss/include/isa/rv32ssr.hpp"
  
+diff --git a/models/cpu/iss/include/exec/exec_inorder_implem.hpp b/models/cpu/iss/include/exec/exec_inorder_implem.hpp
+index 85018018..edf88094 100644
+--- a/models/cpu/iss/include/exec/exec_inorder_implem.hpp
++++ b/models/cpu/iss/include/exec/exec_inorder_implem.hpp
+@@ -77,6 +77,7 @@ static inline iss_reg_t iss_exec_stalled_insn(Iss *iss, iss_insn_t *insn, iss_re
+ 
+ inline int64_t Exec::get_cycles()
+ {
++    // printf("stall cycles:%d\n", this->stall_cycles);
+     return this->iss.top.clock.get_cycles() + this->stall_cycles;
+ }
+ 
+@@ -117,6 +118,7 @@ inline void Exec::insn_hold(vp::ClockEventMeth *meth)
+ inline void Exec::insn_resume()
+ {
+     // Instruction execution can go on
++    // this->trace.msg("[include/exec/exec_inorder_implem.hpp] (addr: 0x%x) insn_resume\n", this->iss.exec.current_insn);
+     this->insn_on_hold = false;
+     this->instr_event.set_callback(&Exec::exec_instr_check_all);
+ }
+@@ -196,7 +198,7 @@ inline void Exec::stalled_dec()
+ 
+ inline void Exec::insn_exec_profiling()
+ {
+-    this->trace.msg("Executing instruction (addr: 0x%x)\n", this->iss.exec.current_insn);
++    this->trace.msg("[include/exec/exec_inorder_implem.hpp] Executing instruction (addr: 0x%x)\n", this->iss.exec.current_insn);
+     if (this->iss.timing.pc_trace_event.get_event_active())
+     {
+         this->iss.timing.pc_trace_event.event((uint8_t *)&this->iss.exec.current_insn);
 diff --git a/models/cpu/iss/include/isa/redmule.hpp b/models/cpu/iss/include/isa/redmule.hpp
 new file mode 100644
 index 00000000..fde9d634
@@ -2634,7 +2663,7 @@ index 26cb748e..412b5077 100644
  #endif 
 \ No newline at end of file
 diff --git a/models/cpu/iss/include/spatz.hpp b/models/cpu/iss/include/spatz.hpp
-index 8b348cd0..3a95941f 100644
+index 8b348cd0..2be6b1ec 100644
 --- a/models/cpu/iss/include/spatz.hpp
 +++ b/models/cpu/iss/include/spatz.hpp
 @@ -29,9 +29,9 @@ typedef uint8_t iss_Vel_t;
@@ -2666,7 +2695,7 @@ index 8b348cd0..3a95941f 100644
  
  private:
      Iss &iss;
-@@ -133,6 +134,15 @@ public:
+@@ -133,6 +134,17 @@ public:
  
      VRegfile vregfile;
      Vlsu vlsu;
@@ -2674,6 +2703,8 @@ index 8b348cd0..3a95941f 100644
 +    uint64_t last_stamp;
 +    uint64_t runtime;
 +
++    // Additional scoreboard for WAR
++    uint64_t reg_war_score_board [ISS_NB_VREGS];
 +    //Scoreboard
 +    uint64_t reg_score_board [ISS_NB_VREGS];
 +    uint64_t unit_score_board [3]; //fpu, slide, vlsu
@@ -2870,6 +2901,23 @@ index 3c39da9e..83572133 100644
              #                           V 1.0
              Instr('vsetvli' ,   Format_OPVLI,    '- ----------- ----- 111 ----- 1010111'), # zimm = {3'b000,vma,vta,vsew[2:0],vlmul[2:0]}
  
+diff --git a/models/cpu/iss/src/exec/exec_inorder.cpp b/models/cpu/iss/src/exec/exec_inorder.cpp
+index fb7456f0..4baf57d3 100644
+--- a/models/cpu/iss/src/exec/exec_inorder.cpp
++++ b/models/cpu/iss/src/exec/exec_inorder.cpp
+@@ -255,9 +255,11 @@ void Exec::exec_instr_check_all(vp::Block *__this, vp::ClockEvent *event)
+     Iss *iss = (Iss *)__this;
+     Exec *_this = &iss->exec;
+ 
++    _this->trace.msg(vp::Trace::LEVEL_TRACE, "[src/exec/exec_inorder.cpp - PRE STALL] (pc: 0x%lx) stall: %d\n", iss->exec.current_insn, iss->exec.stall_cycles);
++
+     if (iss->exec.handle_stall_cycles()) return;
+ 
+-    _this->trace.msg(vp::Trace::LEVEL_TRACE, "Handling instruction with slow handler (pc: 0x%lx)\n", iss->exec.current_insn);
++    _this->trace.msg(vp::Trace::LEVEL_TRACE, "[src/exec/exec_inorder.cpp] Handling instruction with slow handler (pc: 0x%lx)\n", iss->exec.current_insn);
+ 
+     if(_this->pending_flush)
+     {
 diff --git a/models/cpu/iss/src/snitch/decode.cpp b/models/cpu/iss/src/snitch/decode.cpp
 index 6bf10c9b..a6efa5a0 100644
 --- a/models/cpu/iss/src/snitch/decode.cpp
@@ -2922,10 +2970,10 @@ index c7b46b87..d4cb9adb 100644
      // -----------USE MASTER AND SLAVE PORT TO HANDLE OFFLOAD REQUEST------------------
      this->event = this->top.event_new((vp::Block *)this, handle_event);
 diff --git a/models/cpu/iss/src/spatz.cpp b/models/cpu/iss/src/spatz.cpp
-index e4cb6c51..60c463db 100644
+index e4cb6c51..1cd8f155 100644
 --- a/models/cpu/iss/src/spatz.cpp
 +++ b/models/cpu/iss/src/spatz.cpp
-@@ -8,8 +8,17 @@
+@@ -8,8 +8,18 @@
  
  
  Spatz::Spatz(Iss &iss)
@@ -2936,6 +2984,7 @@ index e4cb6c51..60c463db 100644
 +    for (int i = 0; i < ISS_NB_VREGS; ++i)
 +    {
 +        this->reg_score_board[i] = 0;
++        this->reg_war_score_board[i] = 0;
 +    }
 +    for (int i = 0; i < 3; ++i)
 +    {
@@ -2944,7 +2993,7 @@ index e4cb6c51..60c463db 100644
  }
  
  void Spatz::build()
-@@ -25,6 +34,48 @@ VRegfile::VRegfile(Iss &iss) : iss(iss){
+@@ -25,6 +35,64 @@ VRegfile::VRegfile(Iss &iss) : iss(iss){
      VRegfile::reset(true);
  }
  
@@ -2958,22 +3007,29 @@ index e4cb6c51..60c463db 100644
 +        meet_point = (this->unit_score_board[uint_id] > meet_point)? this->unit_score_board[uint_id] : meet_point;
 +    }
 +
++
 +    if (vs1 >= 0)
 +    {
 +        meet_point = (this->reg_score_board[vs1] > meet_point)? this->reg_score_board[vs1] : meet_point;
 +    }
++
 +
 +    if (vs2 >= 0)
 +    {
 +        meet_point = (this->reg_score_board[vs2] > meet_point)? this->reg_score_board[vs2] : meet_point;
 +    }
 +
-+    delay = meet_point - timestamp;
-+    if (uint_id == 2 && (this->unit_score_board[2] > timestamp))
++    // bowwang: handle WAR
++    if (vd >= 0)
 +    {
-+        latency = latency - (this->unit_score_board[2] - timestamp);
++        meet_point = (this->reg_war_score_board[vd] > meet_point)? this->reg_war_score_board[vd] : meet_point;
++    }
++    // bowwang: handle two vle instr in a row
++    if (uint_id == 2){
++        meet_point = (this->unit_score_board[2] > meet_point)? this->unit_score_board[2] : meet_point; 
 +    }
 +    
++    delay = meet_point - timestamp;
 +    future_point = meet_point + latency;
 +
 +    uint64_t add_runtime = (this->last_stamp >= future_point)? 0: (this->last_stamp >= meet_point)? future_point - this->last_stamp : future_point - meet_point;
@@ -2986,6 +3042,15 @@ index e4cb6c51..60c463db 100644
 +    {
 +        this->reg_score_board[vd] = future_point;
 +    }
++    // bowwang: war dependency
++    if (vs1 >= 0)
++    {
++        this->reg_war_score_board[vs1] = future_point;
++    }
++    if (vs2 >= 0)
++    {
++        this->reg_war_score_board[vs2] = future_point;
++    }
 +
 +    return delay;
 +}
@@ -2993,7 +3058,7 @@ index e4cb6c51..60c463db 100644
  
  
  void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
-@@ -34,17 +85,17 @@ void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
+@@ -34,17 +102,17 @@ void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
  
  Vlsu::Vlsu(Iss &iss) : iss(iss)
  {
@@ -3014,7 +3079,7 @@ index e4cb6c51..60c463db 100644
  }
  inline void VRegfile::reset(bool active){
      if (active){
-@@ -56,9 +107,9 @@ inline void VRegfile::reset(bool active){
+@@ -56,9 +124,9 @@ inline void VRegfile::reset(bool active){
      }
  }
  


### PR DESCRIPTION
## 🚀 Summary

This PR introduces several updates across the Spatz project to enhance kernel support, benchmarking, and usability.

---

## ✅ Changes

- **[Makefile]**
  - Added `trace_clean` target to simplify trace cleanup.

- **[spatz]**
  - Integrated WAW/WAR timing model support to improve simulation accuracy.

- **[software]**
  - Added WX-optimized kernel implementations for improved performance.

- **[util]**
  - Introduced `spatz_auto_benchmark.sh` to automate performance benchmarking across kernels.

- **[README]**
  - Added descriptions for newly added kernels.
  - Documented usage of the auto-benchmark script.
  - Minor formatting improvements.

---

## 🧪 Testing

All new kernel and utility changes were tested using the provided auto-benchmarking flow.
