### PR TITLE
N:M multi format + kernel & timing-model updates

### DIFF
--- a/examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py
+++ b/examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py
@@ -46,6 +46,10 @@ class FlexClusterArch:
         self.spatz_num_vlsu_port     = 4
         self.spatz_num_function_unit = 4
         self.spatz_vlsu_port_width   = 64
+        # By defalut (1), gather within vreg have the same bandwidth as VPU
+        # Too pass this value to .inc files, simply x100 (i.e. 1.5 --> 150)
+        # We handle this ratio in the Spatz timing model (rv32v.hpp)
+        self.spatz_vreg_gather_eff = 100
 
         #RedMule
         self.redmule_ce_height       = 128

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_matmul.h
@@ -607,6 +607,16 @@ void spatz_AspB_matmul_unroll4x2_wxfp16(uint8_t* matrix_a, uint8_t* matrix_b, ui
     uint32_t avl = P * spN / spM;
     uint32_t vl, vl_dump;
 
+    // config n:m format (nmconfig.v N:M=2:4)
+    asm volatile(
+        ".word  (0b100000  << 26) | \
+                (0b1       << 25) | \
+                (0b00000   << 20) | \
+                (0b00100   << 15) | \
+                (0b000     << 12) | \
+                (0b00010   <<  7) | \
+                (0b1010110 <<  0)   \n");
+
     do{ // outer loop 
         asm volatile("vsetvli %0, %1, e8, m2, ta, ma" : "=r"(vl) : "r"(avl));
         for (uint32_t m = 0; m < M; m+=4){ // mid loop

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_rvv_extensions.h
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/include/spatz_rvv_extensions.h
@@ -1,0 +1,97 @@
+/* spatz_rvv_extensions.h — C-safe helpers for custom OPVFX encodings
+ *
+ * Layout (per your spec):
+ * [31:26] funct6 | [25] vm | [24:20] vs2 | [19:15] vs1 | [14:12] frs1(3b)
+ * [11:7]  vd     | [6:0]  opcode(0x56)
+ */
+
+#ifndef SPATZ_RVV_EXTENSIONS_H
+#define SPATZ_RVV_EXTENSIONS_H
+
+#include <stdint.h>
+
+/* ---------- Opcode / funct6 ---------- */
+#define OPC_OPVFX           0x56u      /* [6:0] */
+#define FUNCT6_VFWXMACC     0x31u      /* 110001b -> [31:26] */
+#define FUNCT6_VFWXMUL      0x33u      /* 110011b -> [31:26] */
+
+/* ---------- Register index constants (NUMBERS, not names) ---------- */
+/* Vector regs v0..v31 */
+#define RVV_V0   0u
+#define RVV_V1   1u
+#define RVV_V2   2u
+#define RVV_V3   3u
+#define RVV_V4   4u
+#define RVV_V5   5u
+#define RVV_V6   6u
+#define RVV_V7   7u
+#define RVV_V8   8u
+#define RVV_V9   9u
+#define RVV_V10 10u
+#define RVV_V11 11u
+#define RVV_V12 12u
+#define RVV_V13 13u
+#define RVV_V14 14u
+#define RVV_V15 15u
+#define RVV_V16 16u
+#define RVV_V17 17u
+#define RVV_V18 18u
+#define RVV_V19 19u
+#define RVV_V20 20u
+#define RVV_V21 21u
+#define RVV_V22 22u
+#define RVV_V23 23u
+#define RVV_V24 24u
+#define RVV_V25 25u
+#define RVV_V26 26u
+#define RVV_V27 27u
+#define RVV_V28 28u
+#define RVV_V29 29u
+#define RVV_V30 30u
+#define RVV_V31 31u
+
+/* frs1 (3 bits) — ft0..ft7 only */
+#define RVF_RS1_FT0 0u
+#define RVF_RS1_FT1 1u
+#define RVF_RS1_FT2 2u
+#define RVF_RS1_FT3 3u
+#define RVF_RS1_FT4 4u
+#define RVF_RS1_FT5 5u
+#define RVF_RS1_FT6 6u
+#define RVF_RS1_FT7 7u
+
+/* ---------- Core encoder (macro => compile-time const when given const args) ---------- */
+#define ENCODE_OPVFX(funct6, vm, vs2, vs1, frs1_3b, vd) (        \
+    ((uint32_t)((funct6)   & 0x3Fu) << 26) |                      \
+    ((uint32_t)((vm)       & 0x01u) << 25) |                      \
+    ((uint32_t)((vs2)      & 0x1Fu) << 20) |                      \
+    ((uint32_t)((vs1)      & 0x1Fu) << 15) |                      \
+    ((uint32_t)((frs1_3b)  & 0x07u) << 12) |                      \
+    ((uint32_t)((vd)       & 0x1Fu) <<  7) |                      \
+    ((uint32_t)OPC_OPVFX) )
+
+/* ---------- Per-instruction wrappers ---------- */
+#define VFWXMACC_VF(vd, vs2, vs1, frs1_3b, vm) \
+    ENCODE_OPVFX(FUNCT6_VFWXMACC, (vm), (vs2), (vs1), (frs1_3b), (vd))
+
+#define VFWXMUL_VF(vd, vs2, vs1, frs1_3b, vm) \
+    ENCODE_OPVFX(FUNCT6_VFWXMUL,  (vm), (vs2), (vs1), (frs1_3b), (vd))
+
+/* ---------- Emission helpers ---------- */
+/* Use when all args are compile-time constants: puts the word directly. */
+#define EMIT_WORD_IMM(word32_const) \
+    asm volatile(".word %0" :: "i"( (uint32_t)(word32_const) ))
+
+/* Use when any arg is runtime/computed: loads into a temp reg then emits. */
+#define EMIT_WORD_REG(word32_val) do {      \
+    uint32_t __w = (uint32_t)(word32_val);  \
+    asm volatile(".word %0" :: "r"(__w));   \
+} while (0)
+
+/* Optional compile-time range checks when using C11+ */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define SPATZ_STATIC_ASSERT(expr, msg) _Static_assert((expr), msg)
+SPATZ_STATIC_ASSERT(OPC_OPVFX <= 0x7F, "opcode must fit in 7 bits");
+#endif
+
+#endif /* SPATZ_RVV_EXTENSIONS_H */

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/main.c
@@ -107,7 +107,8 @@ int main()
         // spatz_AspB_matmul_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
         // spatz_AspB_matmul_unroll4_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
         // spatz_AspB_matmul_unroll2x2_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
-        spatz_AspB_matmul_unroll4x2_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
+        // spatz_AspB_matmul_unroll4x2_wxfp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
+        spatz_AspB_matmul_unroll4x2_wxfp16_opt(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
         #else
         spatz_AspB_matmul_fp16(matrix_a, matrix_b, matrix_c, index_b, FP8_M, FP8_N, FP8_P, spN, spM);
         #endif

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_auto_benchmark.sh
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_auto_benchmark.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 # List of P values to test
-P_VALUES=(32 128 512 1024)
+# P_VALUES=(32 128 512 1024)
+P_VALUES=(128)
 
 for P in "${P_VALUES[@]}"; do
   echo "Running with P=$P"
 
   # Run data generation script
   python examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_matmul_datagen.py \
-    -M 32 -N 32 -P $P -spN 2 -spM 4 --sparse --idx_compact
+    -M 32 -N 32 -P $P -spN 1 -spM 2 --sparse --idx_compact
 
   # Run make commands
   cfg=examples/SoftHier/assembled/Spatz_GEMM/config/arch_spatz.py \

--- a/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_matmul_datagen.py
+++ b/examples/SoftHier/assembled/Spatz_GEMM/software/util/spatz_matmul_datagen.py
@@ -18,7 +18,7 @@
 import os
 import numpy as np
 import argparse
-from flex_libfp8 import write_matrix_to_header, write_index_to_header, generate_sparse_fp8_matrix, generate_fp8_matrix, extract_nm_sparsity
+from flex_libfp8 import write_matrix_to_header, generate_sparse_fp8_matrix, generate_fp8_matrix, extract_nm_sparsity, write_index_to_header_multi_format
 
 def main():
     parser = argparse.ArgumentParser(description='FP8 Matrix Generator')
@@ -40,6 +40,7 @@ def main():
 
     M, N, P = args.M, args.N, args.P
     spM, spN = args.spM, args.spN
+    fmt_str = f"{spN}:{spM}"
     _sparse = args.sparse
     _idx_compact = args.idx_compact
 
@@ -100,7 +101,7 @@ def main():
             if not _idx_compact:
                 write_matrix_to_header(f, 'matrix_b_index_uint8', B_index, fmt='uint8', dtype='uint8_t')
             else:
-                write_index_to_header(f, 'matrix_b_index_compact_uint8', B_index, fmt='nm2bit', dtype='uint8_t')
+                write_index_to_header_multi_format(f, 'matrix_b_index_compact_uint8', B_index, fmt=fmt_str)
             
         if args.output_format == 'fp16':
             write_matrix_to_header(f, 'matrix_c_fp16', C, fmt='fp16', dtype='uint16_t')

--- a/examples/SoftHier/software/spatz_check/include/spatz_custom_isa.h
+++ b/examples/SoftHier/software/spatz_check/include/spatz_custom_isa.h
@@ -74,6 +74,16 @@ void test_spatz_isa(){
         }
         uint8_t s_fp8[1] =  {0xB5,};
 
+        // config n:m format (nmconfig.v N:M=2:4)
+        asm volatile(
+            ".word  (0b100000  << 26) | \
+                    (0b1       << 25) | \
+                    (0b00000   << 20) | \
+                    (0b00100   << 15) | \
+                    (0b000     << 12) | \
+                    (0b00010   <<  7) | \
+                    (0b1010110 <<  0)   \n");
+
         // vfwxmul.vf
         printf("[ins] vfwxmul.vf \n");
         do{

--- a/examples/SoftHier/software/test/include/hello_world.h
+++ b/examples/SoftHier/software/test/include/hello_world.h
@@ -433,5 +433,74 @@ void test_malloc_single_cluster(){
     flex_intra_cluster_sync();//Cluster barrier
     flex_global_barrier_xy();//Global barrier
 }
+
+void test_nm_config(){
+    flex_global_barrier_xy();//Global barrier
+    flex_intra_cluster_sync();//Cluster barrier
+
+    uint32_t CID = flex_get_cluster_id();//Get cluster ID
+
+    // test memory allocation with 1 cluster (CID==0)
+    if (flex_is_first_core() && (CID == 0))//Use the first core for memory allocation
+        {
+            // nmconfig.v N:M=1:2
+            asm volatile(
+                ".word  (0b100000  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00000   << 20) | \
+                        (0b00010   << 15) | \
+                        (0b000     << 12) | \
+                        (0b00001   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+            // nmconfig.v N:M=2:4
+            asm volatile(
+                ".word  (0b100000  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00000   << 20) | \
+                        (0b00100   << 15) | \
+                        (0b000     << 12) | \
+                        (0b00010   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+            // nmconfig.v N:M=4:8
+            asm volatile(
+                ".word  (0b100000  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00000   << 20) | \
+                        (0b01000   << 15) | \
+                        (0b000     << 12) | \
+                        (0b00100   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+            // nmconfig.v N:M=4:16
+            asm volatile(
+                ".word  (0b100000  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00000   << 20) | \
+                        (0b10000   << 15) | \
+                        (0b000     << 12) | \
+                        (0b00100   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+            // nmconfig.v N:M=2:3
+            asm volatile(
+                ".word  (0b100000  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00000   << 20) | \
+                        (0b00011   << 15) | \
+                        (0b000     << 12) | \
+                        (0b0010   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+            // nmconfig.v N:M=3:2
+            asm volatile(
+                ".word  (0b100000  << 26) | \
+                        (0b1       << 25) | \
+                        (0b00000   << 20) | \
+                        (0b00010   << 15) | \
+                        (0b000     << 12) | \
+                        (0b0011   <<  7) | \
+                        (0b1010110 <<  0)   \n");
+        }
+
+    flex_intra_cluster_sync();//Cluster barrier
+    flex_global_barrier_xy();//Global barrier
+}
 #endif
 

--- a/examples/SoftHier/software/test/main.c
+++ b/examples/SoftHier/software/test/main.c
@@ -11,7 +11,7 @@ int main()
     /*  Program Execution Region -- Start */
     /**************************************/
 
-    hello_world_all_core();
+    test_nm_config();
 
     /**************************************/
     /*  Program Execution Region -- Stop  */

--- a/examples/SoftHier/software/test/main.c
+++ b/examples/SoftHier/software/test/main.c
@@ -11,7 +11,7 @@ int main()
     /*  Program Execution Region -- Start */
     /**************************************/
 
-    test_nm_config();
+    hello_world_all_cluster();
 
     /**************************************/
     /*  Program Execution Region -- Stop  */

--- a/soft_hier/flex_cluster/cluster_unit.py
+++ b/soft_hier/flex_cluster/cluster_unit.py
@@ -79,7 +79,7 @@ class ClusterArch:
                         idma_outstand_txn,  idma_outstand_burst,
                         num_cluster_x,      num_cluster_y,
                         spatz_core_list,    spatz_num_vlsu,     spatz_num_fu,
-                        spatz_vlsu_bw,
+                        spatz_vlsu_bw,      spatz_vreg_gather_eff,
                         data_bandwidth,     auto_fetch=False,   multi_idma_enable=0):
 
         self.nb_core                = nb_core_per_cluster
@@ -99,6 +99,7 @@ class ClusterArch:
         self.spatz_num_vlsu         = spatz_num_vlsu
         self.spatz_num_fu           = spatz_num_fu
         self.spatz_vlsu_bw          = spatz_vlsu_bw
+        self.spatz_vreg_gather_eff  = spatz_vreg_gather_eff
 
         #RedMule
         self.redmule_ce_height      = redmule_ce_height
@@ -225,11 +226,13 @@ class ClusterUnit(gvsoc.systree.Component):
         for core_id in range(0, arch.nb_core):
             cores.append(iss.Snitch(self, f'pe{core_id}', isa='rv32imfdva',
                 fetch_enable=arch.auto_fetch, boot_addr=boot_addr,
-                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu, spatz_vlsu_bw=arch.spatz_vlsu_bw))
+                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu, spatz_vlsu_bw=arch.spatz_vlsu_bw,
+                spatz_vreg_gather_eff=arch.spatz_vreg_gather_eff))
 
             fp_cores.append(iss.Snitch_fp_ss(self, f'fp_ss{core_id}', isa='rv32imfdva',
                 fetch_enable=arch.auto_fetch, boot_addr=boot_addr,
-                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu, spatz_vlsu_bw=arch.spatz_vlsu_bw))
+                core_id=core_id, htif=False, inc_spatz=(len(arch.spatz_core_list) > 0), spatz_num_vlsu=arch.spatz_num_vlsu, spatz_num_fpu=arch.spatz_num_fu, spatz_vlsu_bw=arch.spatz_vlsu_bw,
+                spatz_vreg_gather_eff=arch.spatz_vreg_gather_eff))
             if xfrep:
                 fpu_sequencers.append(Sequencer(self, f'fpu_sequencer{core_id}', latency=0))
 

--- a/soft_hier/flex_cluster/flex_cluster.py
+++ b/soft_hier/flex_cluster/flex_cluster.py
@@ -73,6 +73,7 @@ class FlexClusterSystem(gvsoc.systree.Component):
         # implicitly setting #
         ######################
         if not hasattr(arch, 'spatz_vlsu_port_width'): arch.spatz_vlsu_port_width = 32
+        if not hasattr(arch, 'spatz_vreg_gather_eff'): arch.spatz_vreg_gather_eff = 100
         if not hasattr(arch, 'multi_idma_enable'): arch.multi_idma_enable = 0
         if not hasattr(arch, 'hbm_node_aliase'): arch.hbm_node_aliase = 1
         if not hasattr(arch, 'hbm_node_aliase_start_bit'): arch.hbm_node_aliase_start_bit = 48

--- a/soft_hier/flex_cluster/flex_cluster.py
+++ b/soft_hier/flex_cluster/flex_cluster.py
@@ -141,6 +141,7 @@ class FlexClusterSystem(gvsoc.systree.Component):
                                         spatz_num_vlsu      =   arch.spatz_num_vlsu_port,
                                         spatz_num_fu        =   arch.spatz_num_function_unit,
                                         spatz_vlsu_bw       =   arch.spatz_vlsu_port_width,
+                                        spatz_vreg_gather_eff = arch.spatz_vreg_gather_eff,
                                         data_bandwidth      =   arch.noc_link_width/8,
                                         multi_idma_enable   =   arch.multi_idma_enable)
             cluster_list.append(ClusterUnit(self,f'cluster_{cluster_id}', cluster_arch, binary))

--- a/soft_hier/gvsoc_core.patch
+++ b/soft_hier/gvsoc_core.patch
@@ -195,7 +195,7 @@ index 00000000..fde9d634
 +    return iss_insn_next(iss, insn, pc);
 +}
 diff --git a/models/cpu/iss/include/isa/rv32v.hpp b/models/cpu/iss/include/isa/rv32v.hpp
-index 188f2877..ac83901e 100644
+index 188f2877..c45e5fe0 100644
 --- a/models/cpu/iss/include/isa/rv32v.hpp
 +++ b/models/cpu/iss/include/isa/rv32v.hpp
 @@ -20,8 +20,24 @@
@@ -891,11 +891,16 @@ index 188f2877..ac83901e 100644
      return iss_insn_next(iss, insn, pc);
  }
  
-@@ -1005,7 +1290,22 @@ static inline iss_reg_t vfncvt_rtz_x_f_w_exec(Iss *iss, iss_insn_t *insn, iss_re
+@@ -1005,7 +1290,27 @@ static inline iss_reg_t vfncvt_rtz_x_f_w_exec(Iss *iss, iss_insn_t *insn, iss_re
  
  
  
 +// index scalar-vector multiplication
++static inline iss_reg_t nmconfig_v_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
++    LIB_CALL4(lib_NMCONFIGV , UIM_GET(3), UIM_GET(2), UIM_GET(1), UIM_GET(0));
++    return iss_insn_next(iss, insn, pc);
++}
+ 
 +static inline iss_reg_t vfwxmul_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
 +    LIB_CALL5(lib_FWXMULVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
 +    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +2;
@@ -903,7 +908,7 @@ index 188f2877..ac83901e 100644
 +    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
 +    return iss_insn_next(iss, insn, pc);
 +}
- 
++
 +static inline iss_reg_t vfwxmacc_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
 +    LIB_CALL5(lib_FWXMACCVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
 +    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +3;
@@ -928,7 +933,7 @@ index 84e01c06..cadf5f31 100644
      IssOffloadInsn<iss_reg_t> offload_insn = {
          .opcode=insn->opcode,
 diff --git a/models/cpu/iss/include/isa_lib/vint.h b/models/cpu/iss/include/isa_lib/vint.h
-index 26cb748e..412b5077 100644
+index 26cb748e..2454403f 100644
 --- a/models/cpu/iss/include/isa_lib/vint.h
 +++ b/models/cpu/iss/include/isa_lib/vint.h
 @@ -31,6 +31,12 @@
@@ -1033,7 +1038,7 @@ index 26cb748e..412b5077 100644
 +
 +        int32_t val = i;
 +        bool resBin[64];
-+
+ 
 +        intToBin(SEW, abs(val), resBin);
 +
 +        writeToVReg(iss, SEW, vd, i, resBin);
@@ -1054,7 +1059,7 @@ index 26cb748e..412b5077 100644
 +        myAbs(iss, SEW, vs1, i, &data1);
 +        myAbs(iss, SEW, vs2, i, &data2);
 +        res = data2 << data1;
- 
++
 +        intToBin(SEW, abs(res), resBin);
 +        if(res < 0){
 +            twosComplement(SEW, resBin);
@@ -1394,14 +1399,14 @@ index 26cb748e..412b5077 100644
 -        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
 -        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
 -        iss->spatz.vregfile.vregs[vd][VSTART+1] = data[1];
--
++    uint8_t data[INTF_WIDTH];
+ 
 -        start_add += 2;
 -        align = 2;        
 -    }else if(start_add%4 == 3){
 -        iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,false);
 -        iss->spatz.vregfile.vregs[vd][VSTART+0] = data[0];
-+    uint8_t data[INTF_WIDTH];
- 
+-
 -        start_add += 1;
 -        align = 1;
 -    }else{
@@ -1620,14 +1625,14 @@ index 26cb748e..412b5077 100644
 -        // printf("data3 = %d\n",data[3]);
 -
 -        //printf("vd = %d\n",vd);
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
+ 
 -        //iss->spatz.vregfile.vregs[vd][i+0] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? (data[1]*pow(2,8) + data[0]) : iss->spatz.vregfile.vregs[vd][i+0];
 -        //iss->spatz.vregfile.vregs[vd][i+1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? (data[3]*pow(2,8) + data[2]) : iss->spatz.vregfile.vregs[vd][i+1];
 -
 -        // iss->spatz.vregfile.vregs[vd][i+0] = (data[1]*pow(2,8) + data[0]);
 -        // iss->spatz.vregfile.vregs[vd][i+1] = (data[3]*pow(2,8) + data[2]);
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
- 
+-
 -        iss->spatz.vregfile.vregs[vd][i+0] = data[0];
 -        iss->spatz.vregfile.vregs[vd][i+1] = data[1];
 -        iss->spatz.vregfile.vregs[vd][i+2] = data[2];
@@ -1722,10 +1727,10 @@ index 26cb748e..412b5077 100644
 -        // printf("data1  = %d\n",data[1 ]);
 -        // printf("data2  = %d\n",data[2 ]);
 -        // printf("data3  = %d\n",data[3 ]);
--
--        // printf("addr  = %lu\n",start_add);
 +    for (int i = VSTART+(INTF_WIDTH-align); i < VL; i+=INTF_WIDTH){
  
+-        // printf("addr  = %lu\n",start_add);
+-
 -        //if(!i){
 -            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
 -        //}else{
@@ -1806,8 +1811,7 @@ index 26cb748e..412b5077 100644
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
 -        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
 -        // printf("i = %d\t,vd = %d\n",i,vs3);
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
- 
+-
 -        // printf("STORE16 \n");
 -        // printf("data0  = %d\n",data[0]);
 -        // printf("data1  = %d\n",data[1]);
@@ -1815,7 +1819,8 @@ index 26cb748e..412b5077 100644
 -        // printf("data3  = %d\n",data[3]);
 -
 -        // printf("addr  = %lu\n",start_add);
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*2; i+=INTF_WIDTH){
+ 
 -        //if(!i){
 -            iss->spatz.vlsu.Vlsu_io_access(iss, start_add,4,data,true);
 -        //}else{
@@ -1887,8 +1892,7 @@ index 26cb748e..412b5077 100644
 -        // data[2] = (vm || !(iss->spatz.vregfile.vregs[0][i+0]%2)) ? iss->spatz.vregfile.vregs[vs3][i+0] : 0;
 -        // data[1] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1]/pow(2,8) : 0;
 -        // data[0] = (vm || !(iss->spatz.vregfile.vregs[0][i+1]%2)) ? iss->spatz.vregfile.vregs[vs3][i+1] : 0;
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*4; i+=INTF_WIDTH){
- 
+-
 -        // if(!i){
 -        //     vlsu.Vlsu_io_access(iss, rs1,vlEN/8,data,true);
 -        // }else{
@@ -1899,7 +1903,8 @@ index 26cb748e..412b5077 100644
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
 -        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*4; i+=INTF_WIDTH){
+ 
 -
 -        // printf("STORE32 \n");
 -        // printf("data0  = %d\n",data[0]);
@@ -2011,15 +2016,15 @@ index 26cb748e..412b5077 100644
 -        data[1]  = iss->spatz.vregfile.vregs[vs3][i+1];
 -        data[2]  = iss->spatz.vregfile.vregs[vs3][i+2];
 -        data[3]  = iss->spatz.vregfile.vregs[vs3][i+3];
-+    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
- 
+-
 -
 -        // printf("STORE64 \n");
 -        // printf("data0  = %d\n",data[0]);
 -        // printf("data1  = %d\n",data[1]);
 -        // printf("data2  = %d\n",data[2]);
 -        // printf("data3  = %d\n",data[3]);
--
++    for (int i = VSTART+(INTF_WIDTH-align); i < VL*8; i+=INTF_WIDTH){
+ 
 -        // printf("addr  = %lu\n",start_add);
 -
 -        //if(!i){
@@ -2084,6 +2089,12 @@ index 26cb748e..412b5077 100644
 -    while(i < VL*2){
 -        if(!((i/2)%8)){
 -            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][(i/2)/8],bin);
+-        }
+-        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
+-        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
+-        if(!(!(vm) && !bin[(i/2+0)%8])){
+-            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
 +    for (int i=0; i < VL; i+=1){
 +        // read index
 +        index[0] = iss->spatz.vregfile.vregs[vs2][i];
@@ -2098,12 +2109,6 @@ index 26cb748e..412b5077 100644
 +        for (int j=0; j<sew_bytes; j++){
 +            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
          }
--        index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
--        iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
--        if(!(!(vm) && !bin[(i/2+0)%8])){
--            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
--            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
--        }
 -        i+=2;
      }
  }
@@ -2184,12 +2189,6 @@ index 26cb748e..412b5077 100644
 -            flag = 1;
 -            index = iss->spatz.vregfile.vregs[vs2][int(i/r) - VSTART];
 -            iss->spatz.vlsu.Vlsu_io_access(iss, (start_add+index),4,data,false);
--        }
--        if(!(!(vm) && !bin[(i/8+0)%8])){
--            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
--            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
--            iss->spatz.vregfile.vregs[vd][i+2] = data[2];
--            iss->spatz.vregfile.vregs[vd][i+3] = data[3];
 +        // index load 
 +        uint64_t addr = start_add + (sew_bytes * bytes_to_uint(index, 4));
 +        uint8_t offset = addr % INTF_WIDTH;
@@ -2198,10 +2197,16 @@ index 26cb748e..412b5077 100644
 +        for (int j=0; j<sew_bytes; j++){
 +            iss->spatz.vregfile.vregs[vd][VSTART + i*sew_bytes + j] = data[offset+j];
          }
+-        if(!(!(vm) && !bin[(i/8+0)%8])){
+-            iss->spatz.vregfile.vregs[vd][i+0] = data[0];
+-            iss->spatz.vregfile.vregs[vd][i+1] = data[1];
+-            iss->spatz.vregfile.vregs[vd][i+2] = data[2];
+-            iss->spatz.vregfile.vregs[vd][i+3] = data[3];
+-        }
 -        i+=4;
-     }
- }
- 
+-    }
+-}
+-
 -static inline void lib_VLUXEIV  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, int EEW){
 -    float temp = float(SEW)/float(EEW);
 -    if(SEW == 8){
@@ -2212,9 +2217,9 @@ index 26cb748e..412b5077 100644
 -        lib_VLUXEI32V  (iss, rs1, vs2, vd , vm, temp);
 -    }else if(SEW == 64){
 -        lib_VLUXEI64V  (iss, rs1, vs2, vd , vm, temp);
--    }
--}
--
+     }
+ }
+ 
 -
 -static inline void lib_VSUXEI8V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm, float r){
 +static inline void lib_VLUXEI64V  (Iss *iss, iss_reg_t rs1, int vs2, int vd , bool vm){
@@ -2535,7 +2540,7 @@ index 26cb748e..412b5077 100644
      return VL;
  }
  
-@@ -6943,9 +6895,125 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
+@@ -6943,9 +6895,143 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
          }else{
              AVL = VL;
          }
@@ -2567,9 +2572,27 @@ index 26cb748e..412b5077 100644
 +
 +// index-mul.vf implementation
 +// currently support 2-bit indices for X:4 format
-+#define INDEX_BITS (2)
-+#define SP_N (2)
-+#define SP_M (4)
++#include <bit>  // for std::countr_zero
++static inline void lib_NMCONFIGV (Iss *iss, uint8_t imm3, uint8_t imm2, uint8_t imm1, bool vm){
++    // capture the previous values
++    uint8_t old_n, old_m;
++    old_n = iss->spatz.nm_config_n;
++    old_m = iss->spatz.nm_config_m;
++    // assign the index bit according to m (current;y consider M=2,4,8,16)
++    auto m = imm2;
++    if (((m & (m - 1)) == 0 && m >= 2 && m <= 16) && imm2>imm1) { // m={2,4,8,16} && m>n
++        // assign new n:m values
++        iss->spatz.nm_config_n = imm1;
++        iss->spatz.nm_config_m = imm2;
++        iss->spatz.nm_config_idx_bits = __builtin_ctz(static_cast<unsigned>(m));
++        printf("NM_CONFIG >>> N:M - %d:%d --> %d:%d (idx_bits=%d)\n", old_n, old_m, iss->spatz.nm_config_n, iss->spatz.nm_config_m, iss->spatz.nm_config_idx_bits);
++    } else if (imm2<=imm1){
++        printf("ERROR: Unsupported value M should larger than N, got M=%d, N=%d.\n", imm2, imm1);
++    } else {
++        printf("ERROR: Unsupported M value assigned. m = {2, 4, 8, 16}, got m=%d\n", imm2);
++    }
++}
++
 +static inline void lib_FWXMULVF  (Iss *iss, int vs2, int vs1, int64_t rs1, int vd, bool vm){
 +    bool bin[8];
 +    unsigned long int res, data1, data2, index;
@@ -2583,14 +2606,14 @@ index 26cb748e..412b5077 100644
 +            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
 +        }
 +        // 1. read index 
-+        myAbsINDEX(iss, INDEX_BITS, vs1, i, &index);
++        myAbsINDEX(iss, iss->spatz.nm_config_idx_bits, vs1, i, &index);
 +        // printf("index: %x\n", index);
 +        // 2. read vecotr FP element
 +        myAbsU(iss, SEW, vs2, i, &data2);
 +        EMCase(SEW, &m, &e);
 +        EMCase(SEW*2, &m2, &e2);
 +        // 3. N:M block info
-+        int block_idx = i / SP_N * SP_M;
++        int block_idx = i / iss->spatz.nm_config_n * iss->spatz.nm_config_m;
 +
 +        if(!mask(vm,bin)){
 +            int old = setFFRoundingMode(iss, iss->csr.fcsr.frm);
@@ -2625,9 +2648,9 @@ index 26cb748e..412b5077 100644
 +            intToBin(8,(int64_t) iss->spatz.vregfile.vregs[0][i/8],bin);
 +        }
 +        // 0. N:M block info
-+        int block_idx = i / SP_N * SP_M;
++        int block_idx = i / iss->spatz.nm_config_n * iss->spatz.nm_config_m;
 +        // 1. read index 
-+        myAbsINDEX(iss, INDEX_BITS, vs1, i, &index);
++        myAbsINDEX(iss, iss->spatz.nm_config_idx_bits, vs1, i, &index);
 +        // 2. read vecotr FP element
 +        myAbsU(iss, SEW, vs2, i, &data2);
 +        // gather acc value
@@ -2663,7 +2686,7 @@ index 26cb748e..412b5077 100644
  #endif 
 \ No newline at end of file
 diff --git a/models/cpu/iss/include/spatz.hpp b/models/cpu/iss/include/spatz.hpp
-index 8b348cd0..2be6b1ec 100644
+index 8b348cd0..5e40248c 100644
 --- a/models/cpu/iss/include/spatz.hpp
 +++ b/models/cpu/iss/include/spatz.hpp
 @@ -29,9 +29,9 @@ typedef uint8_t iss_Vel_t;
@@ -2695,7 +2718,7 @@ index 8b348cd0..2be6b1ec 100644
  
  private:
      Iss &iss;
-@@ -133,6 +134,17 @@ public:
+@@ -133,6 +134,22 @@ public:
  
      VRegfile vregfile;
      Vlsu vlsu;
@@ -2710,14 +2733,19 @@ index 8b348cd0..2be6b1ec 100644
 +    uint64_t unit_score_board [3]; //fpu, slide, vlsu
 +    uint64_t max_vlsu_latency;
 +    uint64_t timing_insn(iss_insn_t *insn, int uint_id, int vd, int vs1, int vs2, uint64_t latency, uint64_t timestamp);
++
++    // N:M format configuration e.g, {1:2, 1:4, 2:4, 1:8, 2:8, 4:8, 1:16}
++    uint8_t nm_config_n;  
++    uint8_t nm_config_m;
++    uint8_t nm_config_idx_bits;
  
  };
  
 diff --git a/models/cpu/iss/isa_gen/isa_rvv.py b/models/cpu/iss/isa_gen/isa_rvv.py
-index 3c39da9e..83572133 100644
+index 3c39da9e..d6e0dbff 100644
 --- a/models/cpu/iss/isa_gen/isa_rvv.py
 +++ b/models/cpu/iss/isa_gen/isa_rvv.py
-@@ -77,10 +77,22 @@ Format_OPVL = [ OutReg     (0, Range(7 , 5)),
+@@ -77,10 +77,30 @@ Format_OPVL = [ OutReg     (0, Range(7 , 5)),
                  InReg      (1, Range(20, 5)),
  ]
  
@@ -2731,6 +2759,14 @@ index 3c39da9e..83572133 100644
 +                 UnsignedImm(0, Range(25, 1)),
 +]
 +
++        # 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
++# OPV   #   func6    |m|  imm3   |  imm2   |func3|  imm1   |     op      # 
++Format_OPVCONF = [ UnsignedImm(1, Range(7 , 5)), # imm1
++                   UnsignedImm(2, Range(15, 5)), # imm2
++                   UnsignedImm(3, Range(20, 5)), # imm3
++                   UnsignedImm(0, Range(25, 1)),
++]
++
  class Rv32v(IsaSubset):
  
      def __init__(self):
@@ -2740,7 +2776,7 @@ index 3c39da9e..83572133 100644
              Instr('vadd.vv'       ,   Format_OPV  ,    '000000 - ----- ----- 000 ----- 1010111'),#inst[25] = VM , VM = 0 mask enable
              Instr('vadd.vi'       ,   Format_OPIVI,    '000000 - ----- ----- 011 ----- 1010111'),
              Instr('vadd.vx'       ,   Format_OPV  ,    '000000 - ----- ----- 100 ----- 1010111'),
-@@ -201,84 +213,92 @@ class Rv32v(IsaSubset):
+@@ -201,84 +221,92 @@ class Rv32v(IsaSubset):
  
  
  
@@ -2886,7 +2922,7 @@ index 3c39da9e..83572133 100644
  
              Instr('vfcvt.xu.f.v'     ,   Format_OPV  ,    '010010 - ----- 00000 001 ----- 1010111', tags=['fp_op', 'nseq']),
  
-@@ -374,7 +394,13 @@ class Rv32v(IsaSubset):
+@@ -374,7 +402,14 @@ class Rv32v(IsaSubset):
              Instr('vs2r.v'       ,   Format_OPV  ,    '001 0 001 01000 ----- 000 ----- 0100111'),# vd, (rs1), vm
              Instr('vs4r.v'       ,   Format_OPV  ,    '011 0 001 01000 ----- 000 ----- 0100111'),# vd, (rs1), vm
              Instr('vs8r.v'       ,   Format_OPV  ,    '111 0 001 01000 ----- 000 ----- 0100111'),# vd, (rs1), vm
@@ -2895,6 +2931,7 @@ index 3c39da9e..83572133 100644
 +            # bowwang   
 +            Instr('vid.v'      ,   Format_OPIVI  ,    '010100 - ----- ----- 010 ----- 1010111'),
 +            # Custom ISA for index-sparse
++            Instr('nmconfig.v',   Format_OPVCONF ,  '100000 - ----- ----- 000 ----- 1010110'),
 +            Instr('vfwxmacc.vf',   Format_OPVFX ,    '110001 - ----- ----- --- ----- 1010110'),
 +            Instr('vfwxmul.vf' ,   Format_OPVFX ,    '110011 - ----- ----- --- ----- 1010110'),
 +            
@@ -2970,10 +3007,10 @@ index c7b46b87..d4cb9adb 100644
      // -----------USE MASTER AND SLAVE PORT TO HANDLE OFFLOAD REQUEST------------------
      this->event = this->top.event_new((vp::Block *)this, handle_event);
 diff --git a/models/cpu/iss/src/spatz.cpp b/models/cpu/iss/src/spatz.cpp
-index e4cb6c51..1cd8f155 100644
+index e4cb6c51..e4f8a9f2 100644
 --- a/models/cpu/iss/src/spatz.cpp
 +++ b/models/cpu/iss/src/spatz.cpp
-@@ -8,8 +8,18 @@
+@@ -8,8 +8,22 @@
  
  
  Spatz::Spatz(Iss &iss)
@@ -2990,10 +3027,14 @@ index e4cb6c51..1cd8f155 100644
 +    {
 +        this->unit_score_board[i] = 0;
 +    }
++
++    nm_config_n = 0;
++    nm_config_m = 0;
++    nm_config_idx_bits = 0;
  }
  
  void Spatz::build()
-@@ -25,6 +35,64 @@ VRegfile::VRegfile(Iss &iss) : iss(iss){
+@@ -25,6 +39,64 @@ VRegfile::VRegfile(Iss &iss) : iss(iss){
      VRegfile::reset(true);
  }
  
@@ -3058,7 +3099,7 @@ index e4cb6c51..1cd8f155 100644
  
  
  void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
-@@ -34,17 +102,17 @@ void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
+@@ -34,17 +106,17 @@ void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
  
  Vlsu::Vlsu(Iss &iss) : iss(iss)
  {
@@ -3079,7 +3120,7 @@ index e4cb6c51..1cd8f155 100644
  }
  inline void VRegfile::reset(bool active){
      if (active){
-@@ -56,9 +124,9 @@ inline void VRegfile::reset(bool active){
+@@ -56,9 +128,9 @@ inline void VRegfile::reset(bool active){
      }
  }
  

--- a/soft_hier/gvsoc_core.patch
+++ b/soft_hier/gvsoc_core.patch
@@ -195,7 +195,7 @@ index 00000000..fde9d634
 +    return iss_insn_next(iss, insn, pc);
 +}
 diff --git a/models/cpu/iss/include/isa/rv32v.hpp b/models/cpu/iss/include/isa/rv32v.hpp
-index 188f2877..c45e5fe0 100644
+index 188f2877..55bd9b53 100644
 --- a/models/cpu/iss/include/isa/rv32v.hpp
 +++ b/models/cpu/iss/include/isa/rv32v.hpp
 @@ -20,8 +20,24 @@
@@ -891,7 +891,7 @@ index 188f2877..c45e5fe0 100644
      return iss_insn_next(iss, insn, pc);
  }
  
-@@ -1005,7 +1290,27 @@ static inline iss_reg_t vfncvt_rtz_x_f_w_exec(Iss *iss, iss_insn_t *insn, iss_re
+@@ -1005,7 +1290,32 @@ static inline iss_reg_t vfncvt_rtz_x_f_w_exec(Iss *iss, iss_insn_t *insn, iss_re
  
  
  
@@ -903,7 +903,8 @@ index 188f2877..c45e5fe0 100644
  
 +static inline iss_reg_t vfwxmul_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
 +    LIB_CALL5(lib_FWXMULVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
-+    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +2;
++    uint8_t vreg_gather_penalty = iss->spatz.nm_config_m / iss->spatz.nm_config_n;
++    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) * vreg_gather_penalty;
 +    uint64_t delay = iss->spatz.timing_insn(insn, 0, REG_OUT(0), REG_IN(2), REG_IN(1), latency, iss->top.clock.get_cycles());
 +    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
 +    return iss_insn_next(iss, insn, pc);
@@ -911,7 +912,11 @@ index 188f2877..c45e5fe0 100644
 +
 +static inline iss_reg_t vfwxmacc_vf_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc){
 +    LIB_CALL5(lib_FWXMACCVF , REG_IN(2), REG_IN(1), FREG_GET(0), REG_OUT(0), UIM_GET(0));
-+    uint32_t latency = ((VL + NUM_FPU - 1)/NUM_FPU) +3;
++    // consider gather efficiency
++    float vreg_gather_penalty = static_cast<float>(iss->spatz.nm_config_m) / iss->spatz.nm_config_n / (iss->spatz.vreg_gather_eff/100.0);
++    if (vreg_gather_penalty < 1.0f) vreg_gather_penalty = 1.0f;
++    // cast the FP latency to int
++    uint32_t latency = static_cast<uint32_t>(((VL + NUM_FPU - 1)/NUM_FPU) * vreg_gather_penalty);
 +    uint64_t delay = iss->spatz.timing_insn(insn, 0, REG_OUT(0), REG_IN(2), REG_IN(1), latency, iss->top.clock.get_cycles());
 +    iss->exec.stall_cycles = (iss->exec.stall_cycles > delay)? iss->exec.stall_cycles : delay;
 +    return iss_insn_next(iss, insn, pc);
@@ -933,7 +938,7 @@ index 84e01c06..cadf5f31 100644
      IssOffloadInsn<iss_reg_t> offload_insn = {
          .opcode=insn->opcode,
 diff --git a/models/cpu/iss/include/isa_lib/vint.h b/models/cpu/iss/include/isa_lib/vint.h
-index 26cb748e..2454403f 100644
+index 26cb748e..0431f9a5 100644
 --- a/models/cpu/iss/include/isa_lib/vint.h
 +++ b/models/cpu/iss/include/isa_lib/vint.h
 @@ -31,6 +31,12 @@
@@ -2540,7 +2545,7 @@ index 26cb748e..2454403f 100644
      return VL;
  }
  
-@@ -6943,9 +6895,143 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
+@@ -6943,9 +6895,145 @@ static inline iss_reg_t lib_VSETVL(Iss *iss, int idxRs1, int idxRd, int rs1, int
          }else{
              AVL = VL;
          }
@@ -2585,6 +2590,7 @@ index 26cb748e..2454403f 100644
 +        iss->spatz.nm_config_n = imm1;
 +        iss->spatz.nm_config_m = imm2;
 +        iss->spatz.nm_config_idx_bits = __builtin_ctz(static_cast<unsigned>(m));
++        if (imm2==8) iss->spatz.nm_config_idx_bits = 4; // enforce X:8 format has 4-bit index
 +        printf("NM_CONFIG >>> N:M - %d:%d --> %d:%d (idx_bits=%d)\n", old_n, old_m, iss->spatz.nm_config_n, iss->spatz.nm_config_m, iss->spatz.nm_config_idx_bits);
 +    } else if (imm2<=imm1){
 +        printf("ERROR: Unsupported value M should larger than N, got M=%d, N=%d.\n", imm2, imm1);
@@ -2632,6 +2638,7 @@ index 26cb748e..2454403f 100644
 +            restoreFFRoundingMode(old);
 +            intToBinU(SEW*2, res, resBin);
 +            writeToVReg(iss, SEW*2, vd, block_idx + index, resBin);
++            // printf("final index: %d\n", block_idx + index);
 +        }
 +    }
 +}
@@ -2686,7 +2693,7 @@ index 26cb748e..2454403f 100644
  #endif 
 \ No newline at end of file
 diff --git a/models/cpu/iss/include/spatz.hpp b/models/cpu/iss/include/spatz.hpp
-index 8b348cd0..5e40248c 100644
+index 8b348cd0..93155b84 100644
 --- a/models/cpu/iss/include/spatz.hpp
 +++ b/models/cpu/iss/include/spatz.hpp
 @@ -29,9 +29,9 @@ typedef uint8_t iss_Vel_t;
@@ -2718,7 +2725,7 @@ index 8b348cd0..5e40248c 100644
  
  private:
      Iss &iss;
-@@ -133,6 +134,22 @@ public:
+@@ -133,6 +134,23 @@ public:
  
      VRegfile vregfile;
      Vlsu vlsu;
@@ -2738,6 +2745,7 @@ index 8b348cd0..5e40248c 100644
 +    uint8_t nm_config_n;  
 +    uint8_t nm_config_m;
 +    uint8_t nm_config_idx_bits;
++    float vreg_gather_eff;
  
  };
  
@@ -3007,10 +3015,10 @@ index c7b46b87..d4cb9adb 100644
      // -----------USE MASTER AND SLAVE PORT TO HANDLE OFFLOAD REQUEST------------------
      this->event = this->top.event_new((vp::Block *)this, handle_event);
 diff --git a/models/cpu/iss/src/spatz.cpp b/models/cpu/iss/src/spatz.cpp
-index e4cb6c51..e4f8a9f2 100644
+index e4cb6c51..4db4b1a3 100644
 --- a/models/cpu/iss/src/spatz.cpp
 +++ b/models/cpu/iss/src/spatz.cpp
-@@ -8,8 +8,22 @@
+@@ -8,8 +8,23 @@
  
  
  Spatz::Spatz(Iss &iss)
@@ -3031,10 +3039,11 @@ index e4cb6c51..e4f8a9f2 100644
 +    nm_config_n = 0;
 +    nm_config_m = 0;
 +    nm_config_idx_bits = 0;
++    vreg_gather_eff = CONFIG_GVSOC_ISS_SPATZ_VREG_GATHER_EFF;
  }
  
  void Spatz::build()
-@@ -25,6 +39,64 @@ VRegfile::VRegfile(Iss &iss) : iss(iss){
+@@ -25,6 +40,64 @@ VRegfile::VRegfile(Iss &iss) : iss(iss){
      VRegfile::reset(true);
  }
  
@@ -3099,7 +3108,7 @@ index e4cb6c51..e4f8a9f2 100644
  
  
  void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
-@@ -34,17 +106,17 @@ void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
+@@ -34,17 +107,17 @@ void Vlsu::data_response(vp::Block *__this, vp::IoReq *req)
  
  Vlsu::Vlsu(Iss &iss) : iss(iss)
  {
@@ -3120,7 +3129,7 @@ index e4cb6c51..e4f8a9f2 100644
  }
  inline void VRegfile::reset(bool active){
      if (active){
-@@ -56,9 +128,9 @@ inline void VRegfile::reset(bool active){
+@@ -56,9 +129,9 @@ inline void VRegfile::reset(bool active){
      }
  }
  

--- a/soft_hier/gvsoc_pulp.patch
+++ b/soft_hier/gvsoc_pulp.patch
@@ -1513,10 +1513,10 @@ index e3a0c48..1e66943 100644
      ]
  }
 diff --git a/pulp/snitch/snitch_core.py b/pulp/snitch/snitch_core.py
-index 0bda5e4..896bb54 100644
+index 0bda5e4..186525b 100644
 --- a/pulp/snitch/snitch_core.py
 +++ b/pulp/snitch/snitch_core.py
-@@ -86,20 +86,28 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
+@@ -86,20 +86,29 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
      def __init__(self,
              parent,
              name,
@@ -1530,6 +1530,7 @@ index 0bda5e4..896bb54 100644
 +            spatz_num_vlsu: int=4,
 +            spatz_num_fpu: int=4,
 +            spatz_vlsu_bw: int=32,
++            spatz_vreg_gather_eff: float=1.0,
              core_id: int=0,
              htif: bool=False):
  
@@ -1548,7 +1549,7 @@ index 0bda5e4..896bb54 100644
              add_latencies(isa_instance)
              isa_instances[isa] = isa_instance
  
-@@ -146,17 +154,24 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
+@@ -146,17 +155,25 @@ class Snitch(cpu.iss.riscv.RiscvCommon):
              self.add_sources([
                  "cpu/iss/src/spatz.cpp",
              ])
@@ -1556,6 +1557,7 @@ index 0bda5e4..896bb54 100644
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU={spatz_num_vlsu}'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_FPU={spatz_num_fpu}'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU_BW={spatz_vlsu_bw}'])
++            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VREG_GATHER_EFF={spatz_vreg_gather_eff}'])
  
      def o_BARRIER_REQ(self, itf: gvsoc.systree.SlaveItf):
          self.itf_bind('barrier_req', itf, signature='wire<bool>')
@@ -1574,7 +1576,7 @@ index 0bda5e4..896bb54 100644
              misa: int=None,
              binaries: list=[],
              fetch_enable: bool=False,
-@@ -197,19 +212,27 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
+@@ -197,19 +214,28 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
      def __init__(self,
              parent,
              name,
@@ -1588,6 +1590,7 @@ index 0bda5e4..896bb54 100644
 +            spatz_num_vlsu: int=4,
 +            spatz_num_fpu: int=4,
 +            spatz_vlsu_bw: int=32,
++            spatz_vreg_gather_eff: float=1.0,
              core_id: int=0,
              timed: bool=False,
              htif: bool=False):
@@ -1606,7 +1609,7 @@ index 0bda5e4..896bb54 100644
  
          add_latencies(isa_instance)
  
-@@ -254,6 +277,10 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
+@@ -254,6 +280,11 @@ class Snitch_fp_ss(cpu.iss.riscv.RiscvCommon):
              self.add_sources([
                  "cpu/iss/src/spatz.cpp",
              ])
@@ -1614,10 +1617,11 @@ index 0bda5e4..896bb54 100644
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU={spatz_num_vlsu}'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_FPU={spatz_num_fpu}'])
 +            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VLSU_BW={spatz_vlsu_bw}'])
++            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_SPATZ_VREG_GATHER_EFF={spatz_vreg_gather_eff}'])
  
      def o_BARRIER_REQ(self, itf: gvsoc.systree.SlaveItf):
          self.itf_bind('barrier_req', itf, signature='wire<bool>')
-@@ -266,7 +293,7 @@ class Spatz(cpu.iss.riscv.RiscvCommon):
+@@ -266,7 +297,7 @@ class Spatz(cpu.iss.riscv.RiscvCommon):
      def __init__(self,
              parent,
              name,

--- a/soft_hier/gvsoc_pulp.patch
+++ b/soft_hier/gvsoc_pulp.patch
@@ -1477,6 +1477,41 @@ index 673529f..080f26f 100644
  
  #include <vp/vp.hpp>
  #include <vp/itf/io.hpp>
+diff --git a/pulp/snitch/snitch_cluster/snitch_cluster_peripheral_reg.hjson b/pulp/snitch/snitch_cluster/snitch_cluster_peripheral_reg.hjson
+index e3a0c48..1e66943 100644
+--- a/pulp/snitch/snitch_cluster/snitch_cluster_peripheral_reg.hjson
++++ b/pulp/snitch/snitch_cluster/snitch_cluster_peripheral_reg.hjson
+@@ -411,6 +411,30 @@
+             name: "ICACHE_PREFETCH_ENABLE",
+             desc: "Enable instruction prefetching."
+         }]
++    },
++    {
++        name: "NM_CONFIG",
++        desc: "Structured-sparsity format configuration register",
++        swaccess: "rw",
++        hwaccess: "hrw",
++        resval: "0",
++        fields: [
++            {
++                bits: "3:0",
++                name: "Format_N",
++                desc: "N value in N:M format (1, 2, 3, 4, 8)"
++            },
++            {
++                bits: "7:4",
++                name: "Format_M",
++                desc: "M value in N:M format (2, 4, 8, 16)"
++            },
++            {
++                bits: "31:8",
++                name: "RESERVED",
++                desc: "Reserved bits"
++            }
++        ]
+     }
+     ]
+ }
 diff --git a/pulp/snitch/snitch_core.py b/pulp/snitch/snitch_core.py
 index 0bda5e4..896bb54 100644
 --- a/pulp/snitch/snitch_core.py


### PR DESCRIPTION
# Add configurable n:m sparsity support

This PR introduces runtime **n:m sparsity configurability** across Spatz, utilities, kernels, and tests.

- Added n:m config path + cluster CSR (placeholder)  
- Adapted spGEMM and extended utilities for multiple formats  
- Verified all `_wx` kernels with configurable n:m  
- Added timing model support via **Vreg gather efficiency** (with implicit default)  
- Simplified custom ISA interface for n:m kernels  
- Updated tests to propagate n:m config  

This enables flexible experimentation with different n:m formats while improving timing model accuracy.
