### PR TITLE
chore: update submodule pointers for CV32E40P support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "core"]
 	path = core
-	url = https://github.com/gvsoc/gvsoc-core.git
+	url = https://github.com/marpac3/gvsoc-core.git
 [submodule "pulp"]
 	path = pulp
-	url = https://github.com/gvsoc/gvsoc-pulp.git
+	url = https://github.com/marpac3/gvsoc-pulp.git
 [submodule "gvtest"]
 	path = gvtest
 	url =  https://github.com/gvsoc/gvtest.git


### PR DESCRIPTION
## Summary

Update core and pulp submodule pointers to include CV32E40P ISS support.

**Note**: This PR currently points submodules to `marpac3/` forks where the `mpaci/cv32e40p-clean` branches live. Once the upstream PRs are merged, the submodule pointers should be updated to reference `gvsoc/gvsoc-core` and `gvsoc/gvsoc-pulp` directly.

### Related PRs

- gvsoc/gvsoc-core#146: CV32E40P ISS core model
- gvsoc/gvsoc-pulp#74: CV32E40P standalone platform and core config

### Merge order

1. Merge gvsoc-core#146
2. Merge gvsoc-pulp#74
3. Update this PR's submodule pointers to upstream, then merge