### PR TITLE
ci: run core developer-manual tutorials on github CI

### DIFF
--- a/testset-github.cfg
+++ b/testset-github.cfg
@@ -6,3 +6,4 @@ def testset_build(testset):
     testset.set_name('gvsoc')
 
     testset.import_testset(file='examples/testset.cfg')
+    testset.import_testset(file='core/docs/developer_manual/tutorials/testset.cfg')


### PR DESCRIPTION
## Summary

- `testset-github.cfg` now imports `core/docs/developer_manual/tutorials/testset.cfg` in addition to `examples/testset.cfg`.
- As a result, `make github.test` will run the core-side tutorial test suite on PR CI, including the newly added HWPE tutorial (gvsoc-core PR #149).
- Previously these tutorials only ran via `make test.withbuild` (which is not part of GitHub PR CI).

## Test plan

- [ ] CI green on this PR
- [ ] `tutorials::hwpe_tutorial` (and the other `tutorials::*` entries) appear in the GitHub Actions JUnit report
- [ ] If `tutorials::hwpe_tutorial` times out under the current `--max-timeout 120`, follow up by either bumping the timeout in \`gvsoc/Makefile\`'s \`github.test\` target or splitting \`hwpe_tutorial\` into per-task gvtest entries